### PR TITLE
Using greenlet based servers and authorization

### DIFF
--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -1,14 +1,14 @@
 """Main route for the applciation."""
 
 import json
-from flask import Flask, jsonify, request, abort, Response
+from flask import Flask, jsonify, request, abort
 from flask_restful import Api, Resource
 from flask_cors import CORS
 
 from hydrus.data import crud
-from hydrus.data.user import check_authorization, failed_authentication
+from hydrus.data.user import check_authorization
 from hydrus.utils import get_session, get_doc, get_api_name, get_hydrus_server_url, get_authentication
-# from hydrus.hydraspec.doc_writer_sample import api_doc as doc
+
 import pdb
 
 
@@ -17,6 +17,14 @@ def validObject(object_):
     if "@type" in object_:
         return True
     return False
+
+
+def failed_authentication():
+    """Return failed authentication object."""
+    message = {401: "Need credentials to authenticate"}
+    response = set_response_headers(jsonify(message), status_code=401,
+                                    headers=[{'WWW-Authenticate': 'Basic realm="Login Required"'}])
+    return response
 
 
 def set_response_headers(resp, ct="application/ld+json", headers=[], status_code=200):

--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -1,13 +1,15 @@
 """Main route for the applciation."""
 
 import json
-from flask import Flask, jsonify, request, abort
+from flask import Flask, jsonify, request, abort, Response
 from flask_restful import Api, Resource
 from flask_cors import CORS
 
 from hydrus.data import crud
-from hydrus.utils import get_session, get_doc, get_api_name, get_hydrus_server_url
+from hydrus.data.user import check_authorization, failed_authentication
+from hydrus.utils import get_session, get_doc, get_api_name, get_hydrus_server_url, get_authentication
 # from hydrus.hydraspec.doc_writer_sample import api_doc as doc
+import pdb
 
 
 def validObject(object_):
@@ -90,6 +92,14 @@ class Item(Resource):
 
     def get(self, id_, type_):
         """GET object with id = id_ from the database."""
+        if get_authentication():
+            if request.authorization is None:
+                return failed_authentication()
+            else:
+                auth = check_authorization(request, get_session())
+                if auth is False:
+                    return failed_authentication()
+
         class_type = get_doc().collections[type_]["collection"].class_.title
 
         if checkClassOp(class_type, "GET"):
@@ -106,6 +116,14 @@ class Item(Resource):
 
     def post(self, id_, type_):
         """Update object of type<type_> at ID<id_> with new object_ using HTTP POST."""
+        if get_authentication():
+            if request.authorization is None:
+                return failed_authentication()
+            else:
+                auth = check_authorization(request, get_session())
+                if auth is False:
+                    return failed_authentication()
+
         class_type = get_doc().collections[type_]["collection"].class_.title
 
         if checkClassOp(class_type, "POST"):
@@ -132,6 +150,14 @@ class Item(Resource):
 
     def put(self, id_, type_):
         """Add new object_ optional <id_> parameter using HTTP PUT."""
+        if get_authentication():
+            if request.authorization is None:
+                return failed_authentication()
+            else:
+                auth = check_authorization(request, get_session())
+                if auth is False:
+                    return failed_authentication()
+
         class_type = get_doc().collections[type_]["collection"].class_.title
 
         if checkClassOp(class_type, "PUT"):
@@ -158,6 +184,14 @@ class Item(Resource):
 
     def delete(self, id_, type_):
         """Delete object with id=id_ from database."""
+        if get_authentication():
+            if request.authorization is None:
+                return failed_authentication()
+            else:
+                auth = check_authorization(request, get_session())
+                if auth is False:
+                    return failed_authentication()
+
         class_type = get_doc().collections[type_]["collection"].class_.title
 
         if checkClassOp(class_type, "DELETE"):
@@ -178,6 +212,14 @@ class ItemCollection(Resource):
 
     def get(self, type_):
         """Retrieve a collection of items from the database."""
+        if get_authentication():
+            if request.authorization is None:
+                return failed_authentication()
+            else:
+                auth = check_authorization(request, get_session())
+                if auth is False:
+                    return failed_authentication()
+
         if checkEndpoint("GET", type_):
             # Collections
             if type_ in get_doc().collections:
@@ -205,6 +247,14 @@ class ItemCollection(Resource):
 
     def put(self, type_):
         """Add item to ItemCollection."""
+        if get_authentication():
+            if request.authorization is None:
+                return failed_authentication()
+            else:
+                auth = check_authorization(request, get_session())
+                if auth is False:
+                    return failed_authentication()
+
         if checkEndpoint("PUT", type_):
             object_ = json.loads(request.data.decode('utf-8'))
 
@@ -250,6 +300,14 @@ class ItemCollection(Resource):
 
     def post(self, type_):
         """Update Non Collection class item."""
+        if get_authentication():
+            if request.authorization is None:
+                return failed_authentication()
+            else:
+                auth = check_authorization(request, get_session())
+                if auth is False:
+                    return failed_authentication()
+
         if checkEndpoint("POST", type_):
             object_ = json.loads(request.data.decode('utf-8'))
 
@@ -274,6 +332,14 @@ class ItemCollection(Resource):
 
     def delete(self, type_):
         """Delete a non Collection class item."""
+        if get_authentication():
+            if request.authorization is None:
+                return failed_authentication()
+            else:
+                auth = check_authorization(request, get_session())
+                if auth is False:
+                    return failed_authentication()
+
         if checkEndpoint("DELETE", type_):
             # No Delete Operation for collections
             if type_ in get_doc().parsed_classes and type_+"Collection" not in get_doc().collections:

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -195,6 +195,16 @@ class GraphIIT(Graph):
         return "<subject='%s', predicate='%s', object_='%s'>" % (self.subject, self.predicate, self.object_)
 
 
+class User(Base):
+    """Model for a user that stores the ID, paraphrase and a nonce."""
+
+    __tablename__ = "user"
+
+    id = Column(Integer, primary_key=True)
+    paraphrase = Column(String)
+    nonce = Column(Integer, nullable=True)
+
+
 if __name__ == "__main__":
     print("Creating models....")
     Base.metadata.create_all(engine)

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -202,7 +202,6 @@ class User(Base):
 
     id = Column(Integer, primary_key=True)
     paraphrase = Column(String)
-    nonce = Column(Integer, nullable=True)
 
 
 if __name__ == "__main__":

--- a/hydrus/data/exceptions.py
+++ b/hydrus/data/exceptions.py
@@ -23,10 +23,10 @@ class InstanceNotFound(Exception):
 
     def get_HTTP(self):
         """Return the HTTP response for the Exception."""
-        if self.id_ is None:
+        if str(self.id_) is None:
             return 404, {"message": "Instance of type %s not found" % (self.type_)}
         else:
-            return 404, {"message": "Instance of type %s with ID %s not found" % (self.type_, self.id_)}
+            return 404, {"message": "Instance of type %s with ID %s not found" % (self.type_, str(self.id_))}
 
 
 class PropertyNotFound(Exception):
@@ -51,10 +51,10 @@ class InstanceExists(Exception):
 
     def get_HTTP(self):
         """Return the HTTP response for the Exception."""
-        if self.id_ is None:
+        if str(self.id_) is None:
             return 400, {"message": "Instance of type %salready exists" % (self.type_)}
         else:
-            return 400, {"message": "Instance of type %s with ID %salready exists" % (self.type_, self.id_)}
+            return 400, {"message": "Instance of type %s with ID %salready exists" % (self.type_, str(self.id_))}
 
 
 class NotInstanceProperty(Exception):
@@ -90,4 +90,16 @@ class UserExists(Exception):
 
     def get_HTTP(self):
         """Return the HTTP response for the Exception."""
-        return 400, {"message": "The user with ID %s already exists" % self.id_}
+        return 400, {"message": "The user with ID %s already exists" % str(self.id_)}
+
+
+class UserNotFound(Exception):
+    """Error when the User is not found."""
+
+    def __init__(self, id_):
+        """Constructor."""
+        self.id_ = id_
+
+    def get_HTTP(self):
+        """Return the HTTP response for the Exception."""
+        return 400, {"message": "The User with ID %s is not a valid/defined User" % str(self.id_)}

--- a/hydrus/data/exceptions.py
+++ b/hydrus/data/exceptions.py
@@ -79,3 +79,15 @@ class NotAbstractProperty(Exception):
     def get_HTTP(self):
         """Return the HTTP response for the Exception."""
         return 400, {"message": "The property %s is not an Abstract property" % self.type_}
+
+
+class UserExists(Exception):
+    """Error when the User already exitst."""
+
+    def __init__(self, id_):
+        """Constructor."""
+        self.id_ = id_
+
+    def get_HTTP(self):
+        """Return the HTTP response for the Exception."""
+        return 400, {"message": "The user with ID %s already exists" % self.id_}

--- a/hydrus/data/user.py
+++ b/hydrus/data/user.py
@@ -1,13 +1,13 @@
 """File operations for User authorization."""
 
 from sqlalchemy import exists
-from flask import jsonify
-from hydrus.app import set_response_headers
 from sqlalchemy.orm.exc import NoResultFound
 from hydrus.data.exceptions import UserExists, UserNotFound
 from hydrus.data.db_models import User
 from hashlib import sha224
-import random
+import base64
+# import random
+import pdb
 
 
 def add_user(id_, paraphrase, session):
@@ -15,33 +15,41 @@ def add_user(id_, paraphrase, session):
     if session.query(exists().where(User.id == id_)).scalar():
         raise UserExists(id_=id_)
     else:
-        new_user = User(id_=id_, paraphrase=paraphrase)
+        new_user = User(id=id_, paraphrase=paraphrase)
         session.add(new_user)
         session.commit()
 
+# TODO: Implement handhasking for better security
+# def create_nonce(id_, session):
+#     """Assign a random nonce to the user."""
+#     user = None
+#     try:
+#         user = session.query(User).filter(User.id == id_).one()
+#     except NoResultFound:
+#         raise UserNotFound(id_=id_)
+#     user.nonce = random.randint(1, 1000000)
+#     session.commit()
+#
+#     return user.nonce
 
-def create_nonce(id_, session):
-    """Assign a random nonce to the user."""
-    user = None
-    try:
-        user = session.query(User).filter(User.id_ == id_).one()
-    except NoResultFound:
-        raise UserNotFound(id_=id_)
-    user.nonce = random.randint(1, 1000000)
-    session.commit()
 
-    return user.nonce
+def generate_basic_digest(id_, paraphrase):
+    """Create the digest to be added to the HTTP Authorization header."""
+    paraphrase_digest = sha224(paraphrase.encode('utf-8')).hexdigest()
+    credentials = str(id_) + ':' + paraphrase_digest
+    digest = base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
+    return digest
 
 
 def authenticate_user(id_, hashvalue, session):
-    """Authenticate a user based on the nonce and his paraphrase."""
+    """Authenticate a user based on the ID and his paraphrase."""
     user = None
     try:
-        user = session.query(User).filter(User.id_ == id_).one()
+        user = session.query(User).filter(User.id == id_).one()
     except NoResultFound:
         raise UserNotFound(id_=id_)
     paraphrase = user.paraphrase
-    generated_hash = sha224(paraphrase).hexdigest()
+    generated_hash = sha224(paraphrase.encode('utf-8')).hexdigest()
 
     return generated_hash == hashvalue
 
@@ -50,10 +58,3 @@ def check_authorization(request, session):
     """Check if the request object has the correct authorization."""
     auth = request.authorization
     return authenticate_user(auth.username, auth.password, session)
-
-
-def failed_authentication():
-    """Return failed authentication object."""
-    message = {401: "Need credentials to authenticate"}
-    set_response_headers(jsonify(message), status_code=401,
-                         headers=[{'WWW-Authenticate': 'Basic realm="Login Required"'}])

--- a/hydrus/data/user.py
+++ b/hydrus/data/user.py
@@ -1,0 +1,45 @@
+"""File operations for User authorization."""
+
+from sqlalchemy import exists
+from sqlalchemy.orm.exc import NoResultFound
+from hydrus.data.exceptions import UserExists, UserNotFound
+from hydrus.data.db_models import User
+from hashlib import sha224
+import random
+
+
+def add_user(id_, paraphrase, session):
+    """Add new users to the database."""
+    if session.query(exists().where(User.id == id_)).scalar():
+        raise UserExists(id_=id_)
+    else:
+        new_user = User(id_=id_, paraphrase=paraphrase)
+        session.add(new_user)
+        session.commit()
+
+
+def create_nonce(id_, session):
+    """Assign a random nonce to the user."""
+    user = None
+    try:
+        user = session.query(User).filter(User.id_ == id_).one()
+    except NoResultFound:
+        raise UserNotFound(id_=id_)
+    user.nonce = random.randint(1, 1000000)
+    session.commit()
+
+    return user.nonce
+
+
+def authenticate_user(id_, hashvalue, session):
+    """Authenticate a user based on the nonce and his paraphrase."""
+    user = None
+    try:
+        user = session.query(User).filter(User.id_ == id_).one()
+    except NoResultFound:
+        raise UserNotFound(id_=id_)
+    paraphrase = user.paraphrase
+    nonce = str(user.nonce)
+    generated_hash = sha224(paraphrase+nonce).hexdigest()
+
+    return generated_hash == hashvalue

--- a/hydrus/tests/test_auth.py
+++ b/hydrus/tests/test_auth.py
@@ -1,0 +1,113 @@
+"""Try authorization on all possible URIs on the server."""
+
+from hydrus.data.user import generate_basic_digest
+import json
+import unittest
+from hydrus.app import app_factory
+from hydrus.utils import set_session, set_doc, set_api_name, set_authentication
+from hydrus.data import doc_parse
+from hydrus.hydraspec import doc_writer_sample, doc_maker
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from hydrus.data.db_models import Base
+from hydrus.data.user import add_user
+
+
+# response = requests.get("http://127.0.0.1:8080/serverapi/CommandCollection", headers={'Authorization':'Basic QWxhZGRpbjpPcGVuU2VzYW1l'})
+
+
+class AuthTestCase(unittest.TestCase):
+    """Test Class for the app."""
+
+    @classmethod
+    def setUpClass(self):
+        """Database setup before the tests."""
+        print("Creating a temporary datatbsse...")
+        engine = create_engine('sqlite:///:memory:')
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        self.session = session
+        self.API_NAME = "demoapi"
+        self.HYDRUS_SERVER_URL = "http://hydrus.com/"
+        self.app = app_factory(self.API_NAME)
+        self.doc = doc_maker.createDoc(doc_writer_sample.api_doc.generate(), self.HYDRUS_SERVER_URL, self.API_NAME)
+
+        test_classes = doc_parse.get_classes(self.doc.generate())
+        test_properties = doc_parse.get_all_properties(test_classes)
+        doc_parse.insert_classes(test_classes, self.session)
+        doc_parse.insert_properties(test_properties, self.session)
+        add_user(1, "test", self.session)
+        self.auth_header = {"Authorization": "Basic " + generate_basic_digest(1, "test")}
+        print("Classes, Properties and Users added successfully.")
+        print("Setup done, running tests...")
+
+    @classmethod
+    def tearDownClass(self):
+        """Tear down temporary database."""
+        self.session.close()
+
+    def test_Auth_GET(self):
+        """Test for the index."""
+        with set_api_name(self.app, self.API_NAME):
+            with set_session(self.app, self.session):
+                with set_doc(self.app, self.doc):
+                    with set_authentication(self.app, True):
+                        with self.app.test_client() as client:
+                            response_get = client.get("/"+self.API_NAME)
+                            endpoints = json.loads(response_get.data.decode('utf-8'))
+                            for endpoint in endpoints:
+                                if endpoint in self.doc.collections:
+                                    response_get = client.get(endpoints[endpoint], headers=self.auth_header)
+                                    assert response_get.status_code != 401
+
+    def test_Auth_POST(self):
+        """Test for the index."""
+        with set_api_name(self.app, self.API_NAME):
+            with set_session(self.app, self.session):
+                with set_doc(self.app, self.doc):
+                    with set_authentication(self.app, True):
+                        with self.app.test_client() as client:
+                            response_get = client.get("/"+self.API_NAME)
+                            endpoints = json.loads(response_get.data.decode('utf-8'))
+                            for endpoint in endpoints:
+                                if endpoint in self.doc.collections:
+                                    response_get = client.post(endpoints[endpoint], headers=self.auth_header, data=json.dumps(dict(foo="bar")))
+                                    assert response_get.status_code != 401
+
+    def test_Auth_PUT(self):
+        """Test for the index."""
+        with set_api_name(self.app, self.API_NAME):
+            with set_session(self.app, self.session):
+                with set_doc(self.app, self.doc):
+                    with set_authentication(self.app, True):
+                        with self.app.test_client() as client:
+                            response_get = client.get("/"+self.API_NAME)
+                            endpoints = json.loads(response_get.data.decode('utf-8'))
+                            for endpoint in endpoints:
+                                if endpoint in self.doc.collections:
+                                    response_get = client.put(endpoints[endpoint], headers=self.auth_header, data=json.dumps(dict(foo="bar")))
+                                    assert response_get.status_code != 401
+
+    def test_Auth_DELETE(self):
+        """Test for the index."""
+        with set_api_name(self.app, self.API_NAME):
+            with set_session(self.app, self.session):
+                with set_doc(self.app, self.doc):
+                    with set_authentication(self.app, True):
+                        with self.app.test_client() as client:
+                            response_get = client.get("/"+self.API_NAME)
+                            endpoints = json.loads(response_get.data.decode('utf-8'))
+                            for endpoint in endpoints:
+                                if endpoint in self.doc.collections:
+                                    response_get = client.delete(endpoints[endpoint], headers=self.auth_header)
+                                    assert response_get.status_code != 401
+
+
+if __name__ == '__main__':
+    message = """
+    Running tests for authorization. Checking if all responses are in proper order.
+    """
+    print(message)
+    unittest.main()

--- a/hydrus/utils.py
+++ b/hydrus/utils.py
@@ -58,6 +58,18 @@ def set_doc(application, APIDOC):
         yield
 
 
+@contextmanager
+def set_authentication(application, authentication):
+    """Set the wether API needs to be authenticated or not."""
+    if not isinstance(authentication, bool):
+        raise TypeError("Authentication flag must be of type <bool>")
+
+    def handler(sender, **kwargs):
+        g.authentication = authentication
+    with appcontext_pushed.connected_to(handler, application):
+        yield
+
+
 def get_doc():
     """Get the server API Documentation."""
     apidoc = getattr(g, 'doc', None)
@@ -65,6 +77,15 @@ def get_doc():
         apidoc = doc_writer_sample.api_doc
         g.doc = apidoc
     return apidoc
+
+
+def get_authentication():
+    """Check wether API needs to be authenticated or not."""
+    authentication = getattr(g, 'authentication', None)
+    if authentication is None:
+        authentication = False
+        g.doc = authentication
+    return authentication
 
 
 def get_api_name():

--- a/main.py
+++ b/main.py
@@ -4,10 +4,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from hydrus.app import app_factory
-from hydrus.utils import set_session, set_doc, set_hydrus_server_url, set_api_name
+from hydrus.utils import set_session, set_doc, set_hydrus_server_url, set_api_name, set_authentication
 from hydrus.data import doc_parse
 from hydrus.hydraspec import doc_maker
 from hydrus.data.db_models import Base
+from hydrus.data.user import add_user
 from doc import doc
 from gevent.wsgi import WSGIServer
 
@@ -15,7 +16,8 @@ from gevent.wsgi import WSGIServer
 if __name__ == "__main__":
     # The database connection URL
     # See http://docs.sqlalchemy.org/en/rel_1_0/core/engines.html#sqlalchemy.create_engine for more info
-    DB_URL = 'sqlite:///database.db'
+    # DB_URL = 'sqlite:///database.db'
+    DB_URL = 'sqlite:///:memory:'
 
     # Define the server URL, this is what will be displayed on the Doc
     HYDRUS_SERVER_URL = "http://localhost:8080/"
@@ -42,10 +44,17 @@ if __name__ == "__main__":
 
     print("Adding Classes and Properties")
     # Get all the classes from the doc
-    classes = doc_parse.get_classes(apidoc.generate())     # You can also pass a dictionary as defined in hydrus/hydraspec/doc_writer_sample_output.py
+    classes = doc_parse.get_classes(apidoc.generate())     # You can also pass dictionary defined in hydrus/hydraspec/doc_writer_sample_output.py
 
     # Get all the properties from the classes
     properties = doc_parse.get_all_properties(classes)
+
+    # Insert them into the database
+    doc_parse.insert_classes(classes, session)
+    doc_parse.insert_properties(properties, session)
+
+    print("Adding authorized users")
+    add_user(id_=1, paraphrase="test", session=session)
 
     # Insert them into the database
     doc_parse.insert_classes(classes, session)
@@ -56,14 +65,16 @@ if __name__ == "__main__":
     app = app_factory(API_NAME)
     # Set the name of the API
     print("Starting the application")
-    with set_api_name(app, "serverapi"):
-        # Set the API Documentation
-        with set_doc(app, apidoc):
-            # Set HYDRUS_SERVER_URL
-            with set_hydrus_server_url(app, HYDRUS_SERVER_URL):
-                # Set the Database session
-                with set_session(app, session):
-                    # Start the Hydrus app
-                    http_server = WSGIServer(('', 8080), app)
-                    print("Server running")
-                    http_server.serve_forever()
+    with set_authentication(app, True):
+        # Use authentication for all requests
+        with set_api_name(app, "serverapi"):
+            # Set the API Documentation
+            with set_doc(app, apidoc):
+                # Set HYDRUS_SERVER_URL
+                with set_hydrus_server_url(app, HYDRUS_SERVER_URL):
+                    # Set the Database session
+                    with set_session(app, session):
+                        # Start the Hydrus app
+                        http_server = WSGIServer(('', 8080), app)
+                        print("Server running")
+                        http_server.serve_forever()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 Flask==0.11
+gevent==1.2.2
+greenlet==0.4.12
 Flask-RESTful==0.3.6
 Jinja2==2.9.6
 MarkupSafe==1.0


### PR DESCRIPTION
- Using new greenlet based Python servers. Fixes the problem of dev servers freezing randomly.
- Adding functions for authorization.
- Using HTTP Basic Authorization, using the Authorization Header in the request. 
- User ID and Password hash encrypted in base64 separated by a colon (:) as per the HTTP standard.
  [https://tools.ietf.org/html/rfc7617](https://tools.ietf.org/html/rfc7617)

Todo:
- Need to implement secure TLS communication for the server. Otherwise, the hash may be replicated.
- Implement handshaking between server and client for better security.

