### PR TITLE
feat: Display server URL in output of main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
                         # Start the Hydrus app
                         http_server = WSGIServer(('', 8080), app)
                         print("Server running at:")
-                        print("http://localhost:" + str(http_server.server_port) + "/" + API_NAME)
+                        print(HYDRUS_SERVER_URL + API_NAME)
                         try:
                             http_server.serve_forever()
                         except KeyboardInterrupt:

--- a/main.py
+++ b/main.py
@@ -76,7 +76,8 @@ if __name__ == "__main__":
                     with set_session(app, session):
                         # Start the Hydrus app
                         http_server = WSGIServer(('', 8080), app)
-                        print("Server running")
+                        print("Server running at:")
+                        print("http://localhost:" + str(http_server.server_port) + "/" + API_NAME)
                         try:
                             http_server.serve_forever()
                         except KeyboardInterrupt:


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #103 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.
- [x] I have created/claimed the issue that this PR resolves.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
When the demo server is run, the output of the main.py  file shows the URL it is serving at. The user can now click on the URL from terminal to test it. I have used the WSGIServer `server_port` attribute to dynamically configure the port to display. I thought it would be better than hard coding it.