### PR TITLE
Fix status code response

### DIFF
--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -47,8 +47,8 @@ def hydrafy(object_):
 def check_endpoint(method, type_):
     """Check if endpoint and method is supported in the API."""
     status_val = 404
-    if type_=='vocab':
-        return {'method':False,'status':405}
+    if type_ == 'vocab':
+        return {'method': False, 'status': 405}
 
     for endpoint in get_doc().entrypoint.entrypoint.supportedProperty:
         if type_ == endpoint.name:
@@ -56,8 +56,8 @@ def check_endpoint(method, type_):
             for operation in endpoint.supportedOperation:
                 if operation.method == method:
                     status_val = 200
-                    return {'method':True,'status':status_val}
-    return {'method':False,'status':status_val}
+                    return {'method': True, 'status': status_val}
+    return {'method': False, 'status': status_val}
 
 
 def get_type(class_type, method):

--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -45,7 +45,7 @@ def hydrafy(object_: Dict[str, Any]) -> Dict[str, Any]:
     return object_
 
 
-def checkEndpoint(method: str, type_: str) -> Dict[str, Any]:
+def checkEndpoint(method: str, type_: str) -> Dict[str, Union[bool,int]] :
     """Check if endpoint and method is supported in the API."""
     status_val = 404
     if type_ == 'vocab':

--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -254,7 +254,7 @@ class ItemCollection(Resource):
                     status_code, message = e.get_HTTP()  # type: ignore
                     return set_response_headers(jsonify(message), status_code=status_code)
 
-        endpoint_ = check_endpoint("GET",type_)
+        endpoint_ = checkEndpoint("GET",type_)
         if endpoint_['method']:
             # Collections
             if type_ in get_doc().collections:
@@ -294,7 +294,7 @@ class ItemCollection(Resource):
                     status_code, message = e.get_HTTP()  # type: ignore
                     return set_response_headers(jsonify(message), status_code=status_code)
 
-        endpoint_ = check_endpoint("PUT",type_)
+        endpoint_ = checkEndpoint("PUT",type_)
         if endpoint_['method']:
             object_ = json.loads(request.data.decode('utf-8'))
 
@@ -352,7 +352,7 @@ class ItemCollection(Resource):
                     status_code, message = e.get_HTTP()  # type: ignore
                     return set_response_headers(jsonify(message), status_code=status_code)
 
-        endpoint_ = check_endpoint("POST",type_)
+        endpoint_ = checkEndpoint("POST",type_)
         if endpoint_['method']:
             object_ = json.loads(request.data.decode('utf-8'))
 
@@ -389,7 +389,7 @@ class ItemCollection(Resource):
                     status_code, message = e.get_HTTP()  # type: ignore
                     return set_response_headers(jsonify(message), status_code=status_code)
 
-        endpoint_ = check_endpoint("DELETE",type_)
+        endpoint_ = checkEndpoint("DELETE",type_)
         if endpoint_['method']:
             # No Delete Operation for collections
             if type_ in get_doc().parsed_classes and type_+"Collection" not in get_doc().collections:

--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -45,7 +45,7 @@ def hydrafy(object_: Dict[str, Any]) -> Dict[str, Any]:
     return object_
 
 
-def checkEndpoint(method: str, type_: str) -> Dict[bool,int]:
+def checkEndpoint(method: str, type_: str) -> Dict[str, Any]:
     """Check if endpoint and method is supported in the API."""
     status_val = 404
     if type_ == 'vocab':


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #122 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
The following commits fix the behaviour of status codes returned by the hydrus server for non existing collections.
### Test log
NOTE - I didn't knew how to log tests, so posting a picture of the test runs. Please guide me on that.
![screenshot from 2018-02-25 05-02-43](https://user-images.githubusercontent.com/30872134/36636338-fa3118c8-19ea-11e8-84c8-20ce554013c1.png)

### Changed behaviour
The server initially returned status code 405 for any random url of form `/API_NAME/randomwords`.
The new `check_endpoint` function now provides a `status code 404` for collections not existing in the database. New response attatched below:
![screenshot from 2018-02-25 05-11-19](https://user-images.githubusercontent.com/30872134/36636369-797ecda0-19eb-11e8-9424-313711c8ac2f.png)
