### PR TITLE
Ported from distutils to setuptools. Running setup.py install install…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # !/usr/bin/env python
 """Setup script for Hydrus."""
 
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 setup(name='hydrus',
       version='0.0.1',
@@ -33,11 +33,10 @@ setup(name='hydrus',
           'flask-cors',
           'blinker==1.4',
           'typing==3.6.4',
-          'mypy'
+          'mypy',
+          'gevent==1.2.2',
       ],
-      packages=[
-        'hydrus',
-      ],
+      packages=find_packages(),
       package_dir={'hydrus':
                    'hydrus'},
       )

--- a/setup.py
+++ b/setup.py
@@ -39,4 +39,4 @@ setup(name='hydrus',
       packages=find_packages(),
       package_dir={'hydrus':
                    'hydrus'},
-      )
+     )


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #102 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Ported from distutils to setuptools. Now running `python3 setup.py install` installs all required packages and also adds hydrus to virtualvenv automatically. Before, it had to be done explicitily.

Converting hydrus to a CLI will also be simplified because setuptools offers advanced options.
### Test Logs
<!-- Please submit test logs to confirm everything is working. -->
![image](https://user-images.githubusercontent.com/21313201/36729883-a2b62f72-1beb-11e8-93d1-2d779185dcef.png)
![image](https://user-images.githubusercontent.com/21313201/36729905-b6392ed2-1beb-11e8-9909-23d6890accb9.png)
![image](https://user-images.githubusercontent.com/21313201/36729927-c4b4d8f8-1beb-11e8-814f-6f7c9c72d32a.png)

