### PR TITLE
Added token based authentication feature for user

### DIFF
--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -82,6 +82,7 @@ def checkClassOp(class_type: str, method: str) -> bool:
     return False
 
 def verify_user() -> Union[Response, None]:
+    """ Verify the credentials of the user and assign token."""
     try:
         auth = check_authorization(request, get_session())
         if auth is False:

--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -21,7 +21,7 @@ def validObject(object_: Dict[str, Any]) -> bool:
 
 def token_response(token: str) -> Response:
     """Return succesful token generation object"""
-    message = {"User token": token}
+    message = {200: "User token generated"}
     response = set_response_headers(jsonify(message), status_code=200,
                                     headers=[{'X-Authorization': 'TOKEN ' + token}])
     return response
@@ -36,7 +36,7 @@ def failed_authentication(incorrect: bool) -> Response:
         realm = 'Basic realm="Incorrect credentials"'        
     nonce = create_nonce(get_session())
     response = set_response_headers(jsonify(message), status_code=401,
-                                    headers=[{'WWW-Authenticate': realm},{'Set-Cookie': 'nonce=%s' %nonce}])
+                                    headers=[{'WWW-Authenticate': realm},{'X-Authentication': 'NONCE %s' %nonce}])
     return response
 
 
@@ -106,7 +106,7 @@ def verify_user() -> Union[Response, None]:
 def check_authentication_response() -> Union[Response,None]:
     """ Returns the response as per the authentication requirements."""
     if get_authentication():
-        if request.args and get_token():
+        if get_token():
             token = check_token(request, get_session())
             if not token:
                 if request.authorization is None:

--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -23,7 +23,7 @@ def token_response(token: str) -> Response:
     """Return succesful token generation object"""
     message = {200: "User token generated"}
     response = set_response_headers(jsonify(message), status_code=200,
-                                    headers=[{'X-Authorization': 'TOKEN ' + token}])
+                                    headers=[{'X-Authorization': token}])
     return response
 
 def failed_authentication(incorrect: bool) -> Response:
@@ -36,7 +36,7 @@ def failed_authentication(incorrect: bool) -> Response:
         realm = 'Basic realm="Incorrect credentials"'        
     nonce = create_nonce(get_session())
     response = set_response_headers(jsonify(message), status_code=401,
-                                    headers=[{'WWW-Authenticate': realm},{'X-Authentication': 'NONCE %s' %nonce}])
+                                    headers=[{'WWW-Authenticate': realm},{'X-Authentication': nonce}])
     return response
 
 

--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -6,7 +6,7 @@ from flask_restful import Api, Resource
 from flask_cors import CORS
 
 from hydrus.data import crud
-from hydrus.data.user import check_authorization,add_token,check_token
+from hydrus.data.user import check_authorization, add_token, check_token, create_nonce
 from hydrus.utils import get_session, get_doc, get_api_name, get_hydrus_server_url, get_authentication,get_token
 
 from flask.wrappers import Response
@@ -28,8 +28,9 @@ def token_response(token: str) -> Response:
 def failed_authentication() -> Response:
     """Return failed authentication object."""
     message = {401: "Need credentials to authenticate"}
+    nonce = create_nonce(get_session())
     response = set_response_headers(jsonify(message), status_code=401,
-                                    headers=[{'WWW-Authenticate': 'Basic realm="Login Required"'}])
+                                    headers=[{'WWW-Authenticate': 'Basic realm="Login Required"'},{'Set-Cookie':'nonce=%s' %nonce}])
     return response
 
 
@@ -402,7 +403,7 @@ class Contexts(Resource):
 def app_factory(API_NAME: str="api") -> Flask:
     """Create an app object."""
     app = Flask(__name__)
-
+    app.config['SECRET_KEY'] = 'secret key'
     CORS(app)
     app.url_map.strict_slashes = False
     api = Api(app)

--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -99,8 +99,9 @@ def check_authentication_response() -> Union[Response,None]:
                 if auth is False:
                     return failed_authentication()
                 else:
-                    token = add_token(request, get_session())
-                    return token_response(token)
+                    if get_token():
+                        token = add_token(request, get_session())
+                        return token_response(token)
             except Exception as e:
                 status_code, message = e.get_HTTP()  # type: ignore
                 return set_response_headers(jsonify(message), status_code=status_code)

--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -51,14 +51,18 @@ def validObject(object_: Dict[str, Any]) -> bool:
     return False
 
 def token_response(token: str) -> Response:
-    """Return succesful token generation object"""
+    """
+    Return succesful token generation object
+    """
     message = {200: "User token generated"}
     response = set_response_headers(jsonify(message), status_code=200,
                                     headers=[{'X-Authorization': token}])
     return response
 
 def failed_authentication(incorrect: bool) -> Response:
-    """Return failed authentication object."""
+    """
+    Return failed authentication object.
+    """
     if not incorrect:
         message = {401: "Need credentials to authenticate"}
         realm = 'Basic realm="Login required"'
@@ -121,7 +125,9 @@ def checkClassOp(class_type: str, method: str) -> bool:
     return False
 
 def verify_user() -> Union[Response, None]:
-    """ Verify the credentials of the user and assign token."""
+    """ 
+    Verify the credentials of the user and assign token.
+    """
     try:
         auth = check_authorization(request, get_session())
         if auth is False:
@@ -136,7 +142,9 @@ def verify_user() -> Union[Response, None]:
     return None  
 
 def check_authentication_response() -> Union[Response,None]:
-    """ Returns the response as per the authentication requirements."""
+    """ 
+    Return the response as per the authentication requirements.
+    """
     if get_authentication():
         if get_token():
             token = check_token(request, get_session())

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -204,7 +204,8 @@ class Token(Base):
 
     __tablename__ = "tokens"
     id = Column(String, primary_key = True)
-    user_id = Column(Integer, ForeignKey('user.id')) 
+    user_id = Column(Integer, ForeignKey('user.id'))
+    timestamp = Column(DateTime) 
 
 if __name__ == "__main__":
     print("Creating models....")

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -200,7 +200,7 @@ class User(Base):
     paraphrase = Column(String)
 
 class Token(Base):
-    """Model for storing time bound tokens for the users."""
+    """Model for storing tokens for the users."""
 
     __tablename__ = "tokens"
     id = Column(String, primary_key = True)

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import create_engine, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, DateTime
 from typing import Any
 # from hydrus.settings import DB_URL
 
@@ -199,6 +199,12 @@ class User(Base):
     id = Column(Integer, primary_key=True)
     paraphrase = Column(String)
 
+class Token(Base):
+    """Model for storing time bound tokens for the users."""
+
+    __tablename__ = "tokens"
+    id = Column(String, primary_key = True)
+    user_id = Column(Integer, ForeignKey('user.id')) 
 
 if __name__ == "__main__":
     print("Creating models....")

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -207,6 +207,13 @@ class Token(Base):
     user_id = Column(Integer, ForeignKey('user.id'))
     timestamp = Column(DateTime) 
 
+class Nonce(Base):
+    """Model for storing nonce for the users."""
+
+    __tablename__  = "nonce"
+    id = Column(String, primary_key = True)
+    timestamp = Column(DateTime)
+
 if __name__ == "__main__":
     print("Creating models....")
     Base.metadata.create_all(engine)

--- a/hydrus/data/user.py
+++ b/hydrus/data/user.py
@@ -39,7 +39,10 @@ def check_nonce(request: LocalProxy, session: Session) -> bool:
     return True        
 
 def create_nonce(session: Session) -> str:
-    """Create a one time valid nonce for two factor authentication."""
+    """
+    Create a one time use nonce valid for a short time 
+    for user authentication.
+    """
     nonce = str(uuid4())
     time = datetime.now()
     new_nonce = Nonce(id=nonce, timestamp=time)
@@ -48,9 +51,10 @@ def create_nonce(session: Session) -> str:
     return nonce
 
 def add_token(request: LocalProxy, session: Session) -> str:
-    """Create a new token for the user or return a 
-        valid existing token to the user"""
-
+    """
+    Create a new token for the user or return a 
+    valid existing token to the user.
+    """
     token = None
     id_ = int(request.authorization['username'])
     try:
@@ -72,7 +76,9 @@ def add_token(request: LocalProxy, session: Session) -> str:
     return token.id
 
 def check_token(request: LocalProxy, session: Session) -> bool:
-    """check validity of the token passed by the user."""
+    """
+    check validity of the token passed by the user.
+    """
     token = None
     try:
         id_ = request.headers['X-Authorization']

--- a/hydrus/data/user.py
+++ b/hydrus/data/user.py
@@ -26,7 +26,7 @@ def add_user(id_: int, paraphrase: str, session: Session) -> None:
 def check_nonce(request: LocalProxy, session: Session) -> bool:
     """check validity of nonce passed by the user."""
     try:
-        id_ = request.cookies['nonce']
+        id_ = request.headers['nonce']
         nonce = session.query(Nonce).filter(Nonce.id == id_).one()
         present = datetime.now()
         present = present - nonce.timestamp
@@ -75,7 +75,7 @@ def check_token(request: LocalProxy, session: Session) -> bool:
     """check validity of the token passed by the user."""
     token = None
     try:
-        id_ = request.args['token']
+        id_ = request.headers['token']
         token = session.query(Token).filter(Token.id == id_).one()
         present = datetime.now()
         present = present - token.timestamp

--- a/hydrus/data/user.py
+++ b/hydrus/data/user.py
@@ -57,7 +57,7 @@ def add_token(request: LocalProxy, session: Session) -> str:
         token = session.query(Token).filter(Token.user_id == id_).one()
         present = datetime.now()
         present = present - token.timestamp
-        if present > timedelta(0,0,0,0,2,0,0):
+        if present > timedelta(0,0,0,0,45,0,0):
             update_token = '%030x' % randrange(16**30)
             token.id = update_token
             token.timestamp = datetime.now()
@@ -79,7 +79,7 @@ def check_token(request: LocalProxy, session: Session) -> bool:
         token = session.query(Token).filter(Token.id == id_).one()
         present = datetime.now()
         present = present - token.timestamp
-        if present > timedelta(0,0,0,0,2,0,0):
+        if present > timedelta(0,0,0,0,45,0,0):
             return False
     except:
         return False

--- a/hydrus/data/user.py
+++ b/hydrus/data/user.py
@@ -26,7 +26,7 @@ def add_user(id_: int, paraphrase: str, session: Session) -> None:
 def check_nonce(request: LocalProxy, session: Session) -> bool:
     """check validity of nonce passed by the user."""
     try:
-        id_ = request.headers['nonce']
+        id_ = request.headers['X-Authentication']
         nonce = session.query(Nonce).filter(Nonce.id == id_).one()
         present = datetime.now()
         present = present - nonce.timestamp
@@ -75,7 +75,7 @@ def check_token(request: LocalProxy, session: Session) -> bool:
     """check validity of the token passed by the user."""
     token = None
     try:
-        id_ = request.headers['token']
+        id_ = request.headers['X-Authorization']
         token = session.query(Token).filter(Token.id == id_).one()
         present = datetime.now()
         present = present - token.timestamp

--- a/hydrus/tests/test_auth.py
+++ b/hydrus/tests/test_auth.py
@@ -4,7 +4,7 @@ from hydrus.data.user import generate_basic_digest
 import json
 import unittest
 from hydrus.app import app_factory
-from hydrus.utils import set_session, set_doc, set_api_name, set_authentication
+from hydrus.utils import set_session, set_doc, set_api_name, set_authentication, set_token
 from hydrus.data import doc_parse
 from hydrus.hydraspec import doc_writer_sample, doc_maker
 from sqlalchemy import create_engine
@@ -47,6 +47,7 @@ class AuthTestCase(unittest.TestCase):
         self.session_util = set_session(self.app, self.session)
         self.doc_util = set_doc(self.app, self.doc)
         self.auth_util = set_authentication(self.app, True)
+        self.token_util = set_token(self.app, False)
         self.client = self.app.test_client()
         
         print("Creating utilities context... ")
@@ -54,6 +55,7 @@ class AuthTestCase(unittest.TestCase):
         self.session_util.__enter__()
         self.doc_util.__enter__()
         self.auth_util.__enter__()
+        self.token_util.__enter__()
         self.client.__enter__()
 
         print("Setup done, running tests...")
@@ -64,6 +66,7 @@ class AuthTestCase(unittest.TestCase):
         """Tear down temporary database and exit utilities"""
         self.client.__exit__(None, None, None)
         self.auth_util.__exit__(None, None, None)
+        self.token_util.__exit__(None, None, None)
         self.doc_util.__exit__(None, None, None)
         self.session_util.__exit__(None, None, None)
         self.api_name_util.__exit__(None, None, None)

--- a/hydrus/utils.py
+++ b/hydrus/utils.py
@@ -92,6 +92,16 @@ def set_authentication(application: Flask, authentication: bool) -> Iterator:
     with appcontext_pushed.connected_to(handler, application):
         yield
 
+@contextmanager        
+def set_token(application: Flask, token: bool) -> Iterator:
+    """Set whether API needs to implement token based authentication."""
+    if not isinstance(token, bool):
+        raise TypeError("Token flag must be of type <bool>")
+
+    def handler(sender: Flask, **kwargs: Any) -> None:
+        g.token_ = token
+    with appcontext_pushed.connected_to(handler, application):
+        yield
 
 def get_doc() -> HydraDoc:
     """Get the server API Documentation."""
@@ -110,6 +120,13 @@ def get_authentication() -> bool:
         g.authentication_ = authentication
     return authentication
 
+def get_token() -> bool:
+    """Check wether API needs to be authenticated or not."""
+    token = getattr(g, 'token_', None)
+    if token is None:
+        token = False
+        g.token_ = token
+    return token
 
 def get_api_name() -> str:
     """Get the server API name."""

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker,scoped_session
 
 from hydrus.app import app_factory
-from hydrus.utils import set_session, set_doc, set_hydrus_server_url, set_api_name, set_authentication
+from hydrus.utils import set_session, set_doc, set_hydrus_server_url, set_api_name, set_authentication, set_token
 from hydrus.data import doc_parse
 from hydrus.hydraspec import doc_maker
 from hydrus.data.db_models import Base
@@ -67,18 +67,19 @@ if __name__ == "__main__":
     print("Starting the application")
     with set_authentication(app, True):
         # Use authentication for all requests
-        with set_api_name(app, "serverapi"):
-            # Set the API Documentation
-            with set_doc(app, apidoc):
-                # Set HYDRUS_SERVER_URL
-                with set_hydrus_server_url(app, HYDRUS_SERVER_URL):
-                    # Set the Database session
-                    with set_session(app, session):
-                        # Start the Hydrus app
-                        http_server = WSGIServer(('', 8080), app)
-                        print("Server running at:")
-                        print(HYDRUS_SERVER_URL + API_NAME)
-                        try:
-                            http_server.serve_forever()
-                        except KeyboardInterrupt:
-                            pass
+        with set_token(app, True): 
+            with set_api_name(app, "serverapi"):
+                # Set the API Documentation
+                with set_doc(app, apidoc):
+                    # Set HYDRUS_SERVER_URL
+                    with set_hydrus_server_url(app, HYDRUS_SERVER_URL):
+                        # Set the Database session
+                        with set_session(app, session):
+                            # Start the Hydrus app
+                            http_server = WSGIServer(('', 8080), app)
+                            print("Server running at:")
+                            print(HYDRUS_SERVER_URL + API_NAME)
+                            try:
+                                http_server.serve_forever()
+                            except KeyboardInterrupt:
+                                pass


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #123 #120 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
These changes allow an authenticated user to get a token after authenticating with the server and the token allows the user to access the protected resources of the API by using the token in the url as:
`http:localhost:8080/serverapi/SomeCollection?token="API_TOKEN"` without authorizing itself.
Also this fixes the repetition of code in `app.py` module by combining the authentication steps in on e function #120 (tested the server on browser)

### Test Logs
<!-- Please submit test logs to confirm everything is working. -->
![tests](https://user-images.githubusercontent.com/30872134/36826647-d612905a-1d34-11e8-8931-ecac89021633.png)
### Sample Usage Explanation
1. The user authenticates itself with the server using username and password.

![1](https://user-images.githubusercontent.com/30872134/36826734-8ad5facc-1d35-11e8-8872-0de5f3ceac4a.png)

2. After succesful authentication, the server responds with a server token for further use

![2](https://user-images.githubusercontent.com/30872134/36826748-a22894aa-1d35-11e8-8481-bd0e48b1a412.png)

3. This token can then be used to directly acces the protected endpoints from any source.

![3](https://user-images.githubusercontent.com/30872134/36826784-c37333cc-1d35-11e8-98d9-89ed13875029.png)
NOTE:
1. For now the server issued tokens are generated for infinite time, will add time based destruction of the token in later stages.
2. I have added a `set_token` contextmanager function for now to enable or disable this feature in the API
3. For `auth_tests` currently the `set_token` feature is set to False to comply with the original tests. 