### PR TITLE
Add CLI option to add database and server url

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -19,21 +19,23 @@ import click
                 help="The API name.", type=str)
 @click.option("--auth/--no-auth", default=True,
                 help="Set authentication to True or False.")
+@click.option("--dburl", default="sqlite:///:memory:", help="Set database url", type=str)
 @click.option("--hydradoc", "-d", default="doc.jsonld",
                 help="Location to HydraDocumentation (JSON-LD) of server.",
                 type=click.File('r'))
 @click.option("--port", "-p", default=8080,
                 help="The port the app is hosted at.", type=int)
+@click.option("--serverurl", default= "http://localhost", help="Set server url", type=str)
 @click.argument("serve", required=True)
-def startserver(adduser, api, auth, hydradoc, port, serve):
+def startserver(adduser, api, auth, dburl, hydradoc, port, serverurl, serve):
     """Python Hydrus CLI"""
     # The database connection URL
     # See http://docs.sqlalchemy.org/en/rel_1_0/core/engines.html#sqlalchemy.create_engine for more info
     # DB_URL = 'sqlite:///database.db'
-    DB_URL = 'sqlite:///:memory:'
+    DB_URL = dburl
 
     # Define the server URL, this is what will be displayed on the Doc
-    HYDRUS_SERVER_URL = "http://localhost:" + str(port) + "/"
+    HYDRUS_SERVER_URL = serverurl + ":" + str(port) + "/"
 
     # The name of the API or the EntryPoint, the api will be at http://localhost/<API_NAME>
     API_NAME = api


### PR DESCRIPTION
Closes https://github.com/HTTP-APIs/hydrus/issues/160

<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Add option for setting database URL and server URL in hydrus CLI

### Test Logs
<!-- Please submit test logs to confirm everything is working. -->
![cli](https://user-images.githubusercontent.com/24962153/37151052-0a77d36c-22fa-11e8-9595-6060364477bf.png)
