### PR TITLE
Add default port for utils.set_hydrus_server_url()

### DIFF
--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -20,7 +20,8 @@
     hydrus.utils.get_session : Gets the database session for the server
     hydrus.utils.get_doc : Function which gets the server API documentation
     hydrus.utils.get_api_name : Function which gets the server API name
-    hydrus.utils.get_hydrus_server_url : Function the gets the server URL
+    hydrus.utils.get_hydrus_server_url : Function which gets the server URL
+    hydrus.utils.set_hydrus_server_url : Function the sets the server URL
     hydrus.utils.get_authentication : Function that checks whether API needs to be authenticated or not
 
 """
@@ -32,7 +33,8 @@ from flask_cors import CORS
 
 from hydrus.data import crud
 from hydrus.data.user import check_authorization, add_token, check_token, create_nonce
-from hydrus.utils import get_session, get_doc, get_api_name, get_hydrus_server_url, get_authentication,get_token
+from hydrus.utils import get_session, get_doc, get_api_name, get_hydrus_server_url, \
+    get_authentication, get_token, set_hydrus_server_url
 
 from flask.wrappers import Response
 from typing import Dict, List, Any, Union
@@ -524,5 +526,9 @@ def app_factory(API_NAME: str="api") -> Flask:
 
 if __name__ == "__main__":
 
+    HOST = '127.0.0.1'
+    PORT = 8081
     app = app_factory("api")
-    app.run(host='127.0.0.1', debug=True, port=8080)
+    with app.app_context():
+        with set_hydrus_server_url(app, HOST, PORT):
+            app.run(host=HOST, debug=True, port=PORT)

--- a/hydrus/utils.py
+++ b/hydrus/utils.py
@@ -168,7 +168,7 @@ def get_token() -> bool:
     return token
   
 @contextmanager
-def set_hydrus_server_url(application: Flask, server_url: str) -> Iterator:
+def set_hydrus_server_url(application: Flask, server_url: str, port: int=80) -> Iterator:
     """
     Set the server URL for the app (before it is run in main.py).
     :param application: Flask app object
@@ -178,8 +178,14 @@ def set_hydrus_server_url(application: Flask, server_url: str) -> Iterator:
     """
     if not isinstance(server_url, str):
         raise TypeError("The server_url is not of type <str>")
+    if not isinstance(port, int):
+        raise TypeError("The port number is not of type <int>")
     def handler(sender: Flask, **kwargs: Any) -> None:
-        g.hydrus_server_url = server_url
+        g.hydrus_server_url = '{}:{}'.format(server_url, port)
+        if not g.hydrus_server_url.startswith('http://'):
+            g.hydrus_server_url = 'http://' + g.hydrus_server_url
+        if not g.hydrus_server_url.endswith('/'):
+            g.hydrus_server_url = g.hydrus_server_url + '/'
     with appcontext_pushed.connected_to(handler, application):
         yield
 
@@ -187,13 +193,13 @@ def set_hydrus_server_url(application: Flask, server_url: str) -> Iterator:
 def get_hydrus_server_url() -> str:
     """
     Get the server URL.
-    Returns and sets "http://localhost/" if not found.
+    Returns and sets "http://localhost:8080/" if not found.
     :return hydrus_server_url : Server URL
             <str>
     """
     hydrus_server_url = getattr(g, 'hydrus_server_url', None)
     if hydrus_server_url is None:
-        hydrus_server_url = "http://localhost/"
+        hydrus_server_url = "http://localhost:8080/"
         g.hydrus_server_url = hydrus_server_url
     return hydrus_server_url
 


### PR DESCRIPTION
Fixes #182 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Test Logs
```bash
$ python -m unittest hydrus/tests/*.py
Creating a temporary database...
Classes and properties added successfully.
Setting up Hydrus utilities... 
Creating utilities context... 
Setup done, running tests...
...............Creating a temporary datatbase...
Classes, Properties and Users added successfully.
Setting up Hydrus utilities... 
Creating utilities context... 
Setup done, running tests...
..........Creating a temporary datatbsse...
Classes and properties added successfully.
Setup done, running tests...
..otherClass
........
----------------------------------------------------------------------
Ran 35 tests in 0.403s

OK
```