### PR TITLE
fixed extra _: issue

### DIFF
--- a/hydrus/hydraspec/doc_writer.py
+++ b/hydrus/hydraspec/doc_writer.py
@@ -369,7 +369,7 @@ class EntryPointCollection():
             "writeonly": False
         }  # type: Dict[str, Any]
         for op in self.supportedOperation:
-            operation = EntryPointOp("_:" + op.id_.lower(), op.method,
+            operation = EntryPointOp(op.id_.lower(), op.method,
                                      op.desc, op.expects, op.returns, op.status, type_=op.type_)
             object_["property"]["supportedOperation"].append(
                 operation.generate())
@@ -408,7 +408,7 @@ class EntryPointClass():
             "writeonly": False
         }  # type: Dict[str, Any]
         for op in self.supportedOperation:
-            operation = EntryPointOp("_:" + op.title.lower(), op.method,
+            operation = EntryPointOp(op.title.lower(), op.method,
                                      None, op.expects, op.returns, op.status, label=op.title)
             object_["property"]["supportedOperation"].append(
                 operation.generate())

--- a/hydrus/samples/doc_writer_sample_output.py
+++ b/hydrus/samples/doc_writer_sample_output.py
@@ -185,7 +185,7 @@ doc = {
                         "range": "vocab:dummyClassCollection",
                         "supportedOperation": [
                             {
-                                "@id": "_:_:dummyclass_collection_retrieve",
+                                "@id": "_:dummyclass_collection_retrieve",
                                 "@type": "http://schema.org/FindAction",
                                 "description": "Retrieves all dummyClass entities",
                                 "expects": "null",
@@ -194,7 +194,7 @@ doc = {
                                 "statusCodes": []
                             },
                             {
-                                "@id": "_:_:dummyclass_create",
+                                "@id": "_:dummyclass_create",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "Create new dummyClass entitity",
                                 "expects": "vocab:dummyClass",


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #245 

### Checklist
- [X] My branch is up-to-date with upstream/develop branch.
- [X] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
We had an extra "_:" in every doc , we removed that in this PR .
```
"supportedOperation": [
                            {
                                "@id": "_:_:httpapilog_collection_retrieve",
                                "@type": "hydra:Operation",
                                "description": "Retrieves all HttpApiLog entities",
                                "expects": "null",
                                "method": "GET",
                                "returns": "vocab:HttpApiLogCollection",
                                "statusCodes": []
                            },
                            {
                                "@id": "_:_:httpapilog_create",
                                "@type": "http://schema.org/AddAction",
                                "description": "Create new HttpApiLog entitity",
                                "expects": "vocab:HttpApiLog",
                                "method": "PUT",
                                "returns": "vocab:HttpApiLog",
                                "statusCodes": [
                                    {
                                        "description": "If the HttpApiLog entity was created successfully.",
                                        "statusCode": 201
                                    }
                                ]
                            }
```
### Test Logs
<!-- Please submit test logs to confirm everything is working. -->
<img width="1440" alt="screen shot 2018-07-10 at 1 07 10 pm" src="https://user-images.githubusercontent.com/19390504/42495952-31a90a4c-8442-11e8-9a9d-38cfc5d28a43.png">
