### PR TITLE
Pep8 fix for openapi_parser.py

### DIFF
--- a/hydrus/parser/openapi_parser.py
+++ b/hydrus/parser/openapi_parser.py
@@ -5,7 +5,8 @@ Module to take in Open Api Specification and convert it to HYDRA Api Doc
 import yaml
 import json
 from typing import Any, Dict, Match, Optional, Tuple, Union, List, Set
-from hydrus.hydraspec.doc_writer import HydraDoc, HydraClass, HydraClassProp, HydraClassOp
+from hydrus.hydraspec.doc_writer import (HydraDoc, HydraClass,
+                                         HydraClassProp, HydraClassOp)
 import sys
 
 
@@ -25,7 +26,8 @@ def try_catch_replacement(block: Any, get_this: str, default: Any) -> str:
 
 def generateEntrypoint(api_doc: HydraDoc) -> None:
     """
-    Generates Entrypoint , Base Collection and Base Resource for the documentation
+    Generates Entrypoint ,
+    Base Collection and Base Resource for the documentation
     :param api_doc: contains the Hydra Doc created
     """
     api_doc.add_baseCollection()
@@ -50,7 +52,7 @@ def generate_empty_object() -> Dict[str, Any]:
     return object
 
 
-def check_collection(schema_obj: Dict[str, Any],method: str)->bool:
+def check_collection(schema_obj: Dict[str, Any], method: str) -> bool:
     """
     Checks if the method is collection or not , checks if the method is valid
     :param class_name: name of class being parsed
@@ -72,7 +74,7 @@ def check_collection(schema_obj: Dict[str, Any],method: str)->bool:
     except KeyError:
         collection = False
     # checks if the method is something like 'pet/{petid}'
-    if valid_endpoint(method) == "collection" and collection == False:
+    if valid_endpoint(method) == "collection" and collection is False:
         collection = True
     return collection
 
@@ -136,7 +138,7 @@ def get_data_at_location(
     return data
 
 
-def sanitise_path(path: str)->str:
+def sanitise_path(path: str) -> str:
     """
     Removed any variable present in the path
     :param path:
@@ -161,7 +163,8 @@ def get_class_details(global_: Dict[str,
                       class_name: str,
                       path="") -> None:
     """
-    fetches details of class and adds the class to the dict along with the classDefinition until this point
+    fetches details of class and adds the class to the dict along with the
+    classDefinition until this point
     :param global_: global state
     :param class_name: name of class
     :param data: data from the location given in $ref
@@ -227,11 +230,13 @@ def get_class_details(global_: Dict[str,
                 flag = True
             if vocabFlag:
                 if errFlag:
-                    global_[class_name]["prop_definition"].append(HydraClassProp(
-                        "", prop, required=flag, read=True, write=True))
+                    global_[class_name]["prop_definition"].append(
+                        HydraClassProp("", prop, required=flag, read=True,
+                                       write=True))
                 else:
-                    global_[class_name]["prop_definition"].append(HydraClassProp(
-                        "vocab:" + prop, prop, required=flag, read=True, write=True))
+                    global_[class_name]["prop_definition"].append(
+                        HydraClassProp("vocab:" + prop, prop, required=flag,
+                                       read=True, write=True))
             else:
                 global_[class_name]["prop_definition"].append(HydraClassProp(
                     prop, prop, required=flag, read=True, write=True))
@@ -240,7 +245,7 @@ def get_class_details(global_: Dict[str,
         global_["class_names"].add(class_name)
 
 
-def generateOrUpdateClass(name, collection, global_, path)->bool:
+def generateOrUpdateClass(name, collection, global_, path) -> bool:
     """
     Generates or Updates the class if it already exists
     :param name: class name
@@ -268,26 +273,29 @@ def generateOrUpdateClass(name, collection, global_, path)->bool:
 
 def check_for_ref(global_: Dict[str, Any],
                   path: str,
-                  block: Dict[str, Any])->str:
+                  block: Dict[str, Any]) -> str:
     """
-    Checks for references in responses and parameters key , and adds classes to state
+    Checks for references in responses and parameters key ,
+    and adds classes to state
     :param global_: global state
     :param path: endpoint
     :param block: block containing specific part of doc
     :return: class name
     """
 
-    # will check if there is an external ref , go to that location , add the class in globals , will also verify
+    # will check if there is an external ref , go to that location,
+    # add the class in globals , will also verify
     # if we can parse this method or not , if all good will return class name
     for obj in block["responses"]:
         try:
             try:
                 # can only be internal
-                class_location = block["responses"][obj]["schema"]["$ref"].split(
-                    '/')
+                class_location = block["responses"][obj]["schema"]["$ref"].\
+                    split('/')
             except KeyError:
-                class_location = block["responses"][obj]["schema"]["items"]["$ref"].split(
-                    '/')
+                class_location = \
+                  block["responses"][obj]["schema"]["items"]["$ref"].\
+                  split('/')
             collection = check_collection(
                 schema_obj=block["responses"][obj]["schema"],
                 method=path)
@@ -334,11 +342,12 @@ def check_for_ref(global_: Dict[str, Any],
                 pass
     # cannot parse because no external ref
 
-    print("Cannot parse path" + path + " because no ref to local class provided")
+    print("Cannot parse path" + path +
+          " because no ref to local class provided")
     return ""
 
 
-def allow_parameter(parameter: Dict[str, Any])->bool:
+def allow_parameter(parameter: Dict[str, Any]) -> bool:
     """
     Checks the validity of params that are to be processed
     according to  rules of param passing
@@ -355,7 +364,7 @@ def allow_parameter(parameter: Dict[str, Any])->bool:
 
 
 def get_parameters(global_: Dict[str, Any],
-                   path: str, method: str, class_name: str)->str:
+                   path: str, method: str, class_name: str) -> str:
     """
     Parse paramters from method object
     :param global_: global state
@@ -366,7 +375,8 @@ def get_parameters(global_: Dict[str, Any],
     """
     param = str
     for parameter in global_["doc"]["paths"][path][method]["parameters"]:
-        # will call schema_parse with class name and schema block after checking if type exists
+        # will call schema_parse with class name and schema block
+        # after checking if type exists
         # coz there are instances where no schema key is present
         if allow_parameter(parameter):
             try:
@@ -393,7 +403,7 @@ def get_parameters(global_: Dict[str, Any],
 
 
 def get_ops(global_: Dict[str, Any], path: str,
-            method: Dict[str, Any], class_name: str)->None:
+            method: Dict[str, Any], class_name: str) -> None:
     """
     Get operations from path object and store in global path
     :param global_: global state
@@ -417,7 +427,8 @@ def get_ops(global_: Dict[str, Any], path: str,
             for response in responses:
                 if response != 'default':
                     op_status.append({"statusCode": int(
-                        response), "description": responses[response]["description"]})
+                        response),
+                        "description": responses[response]["description"]})
                 try:
                     op_returns = "vocab:" + \
                         responses[response]["schema"]["$ref"].split('/')[2]
@@ -426,8 +437,8 @@ def get_ops(global_: Dict[str, Any], path: str,
                 if op_returns is None:
                     try:
                         op_returns = "vocab:" + \
-                            responses[response]["schema"]["items"]["$ref"].split(
-                                '/')[2]
+                            responses[response]["schema"]["items"]["$ref"].\
+                            split('/')[2]
                     except KeyError:
                         op_returns = try_catch_replacement(
                             responses[response]["schema"], "type", None)
@@ -509,7 +520,8 @@ def dump_documentation(hydra_doc: Dict[str, Any]) -> str:
     :return:  hydra doc created
     """
     dump = json.dumps(hydra_doc, indent=4, sort_keys=True)
-    hydra_doc = '''"""\nGenerated API Documentation for Server API using server_doc_gen.py."""\n\ndoc = %s''' % dump
+    hydra_doc = '''"""\nGenerated API Documentation for Server API using
+                server_doc_gen.py."""\n\ndoc = %s''' % dump
     hydra_doc = hydra_doc + '\n'
     hydra_doc = hydra_doc.replace('true', '"true"')
     hydra_doc = hydra_doc.replace('false', '"false"')


### PR DESCRIPTION
Fixes #280 
Test logs:
```shell
(venv) usman@lenovo:~/OpenSource/hydrus^pep8-fix ♥
$ python -m unittest hydrus/tests/test_parser.py                            11/19/18 -  8:18 AM
Importing Open Api Documentation ..
......Method on path/pet/findByStatus already present !
Method on path/pet/findByTags already present !
Method on path/pet/{petId} already present !
Cannot parse path/pet/{petId} because no ref to local class provided
Cannot parse path/pet/{petId} because no ref to local class provided
Cannot parse path/store/inventory because no ref to local class provided
Cannot parse path/store/order/{orderId} because no ref to local class provided
Method on path/user/createWithArray already present !
Method on path/user/createWithList already present !
Cannot parse path/user/login because no ref to local class provided
Cannot parse path/user/logout because no ref to local class provided
Cannot parse path/user/{username} because no ref to local class provided
...
----------------------------------------------------------------------
Ran 9 tests in 0.079s

OK

```
Pep8 check:
![image](https://user-images.githubusercontent.com/26684281/48683677-59fac180-ebd4-11e8-8d93-a73d2b8dd360.png)
