### PR TITLE
Add expiry field to Token

### DIFF
--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -3,13 +3,17 @@
 from sqlalchemy import create_engine, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy.sql import func
 from typing import Any
+import datetime
 import uuid
 # from hydrus.settings import DB_URL
 
 engine = create_engine('sqlite:///database.db')
 
 Base = declarative_base()  # type: Any
+
+EXPIRY_TIME = 2700  # unit: seconds
 
 
 class RDFClass(Base):
@@ -171,8 +175,8 @@ class GraphIAC(Graph):
     """Graph model for Instance >> AbstractProperty >> Class."""
 
     __tablename__ = 'graphiac'
-    id = Column(String, ForeignKey('graph.id'), primary_key=True,default=lambda: str(
-            uuid.uuid4()))
+    id = Column(String, ForeignKey('graph.id'), primary_key=True, default=lambda: str(
+        uuid.uuid4()))
     subject = Column(String, ForeignKey("instances.id"))
     predicate = Column(String, ForeignKey("property.id"))
     object_ = Column(String, ForeignKey("classes.id"))
@@ -191,8 +195,8 @@ class GraphIII(Graph):
     """Graph model for Instance >> InstanceProperty >> Instance."""
 
     __tablename__ = 'graphiii'
-    id = Column(String, ForeignKey('graph.id'), primary_key=True,default=lambda: str(
-            uuid.uuid4()))
+    id = Column(String, ForeignKey('graph.id'), primary_key=True, default=lambda: str(
+        uuid.uuid4()))
     subject = Column(String, ForeignKey("instances.id"))
     predicate = Column(String, ForeignKey("property.id"))
     object_ = Column(String, ForeignKey("instances.id"))
@@ -211,8 +215,8 @@ class GraphIIT(Graph):
     """Graph model for Instance >> InstanceProperty >> Terminal."""
 
     __tablename__ = 'graphiit'
-    id = Column(String, ForeignKey('graph.id'), primary_key=True,default=lambda: str(
-            uuid.uuid4()))
+    id = Column(String, ForeignKey('graph.id'), primary_key=True, default=lambda: str(
+        uuid.uuid4()))
     subject = Column(String, ForeignKey("instances.id"))
     predicate = Column(String, ForeignKey("property.id"))
     object_ = Column(String, ForeignKey("terminals.id"))
@@ -240,9 +244,21 @@ class Token(Base):
     """Model for storing tokens for the users."""
 
     __tablename__ = "tokens"
-    id = Column(String, primary_key=True)
+    id = Column(
+        String,
+        default=lambda: str(
+            uuid.uuid4()),
+        unique=True,
+        primary_key=True)
     user_id = Column(Integer, ForeignKey('user.id'))
-    timestamp = Column(DateTime)
+    timestamp = Column(DateTime, default=func.now())
+    expiry = Column('expiry', DateTime, default=datetime.datetime.utcnow() +
+                    datetime.timedelta(seconds=EXPIRY_TIME))
+
+    def is_valid(self):
+        if self.expiry > datetime.datetime.utcnow():
+            return True
+        return False
 
 
 class Nonce(Base):


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #178

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
 - The PR adds a `expiry` field to Token with an expiration time of 2700 seconds and makes the necessary changes in the dependent functions.
 - A possible addition could be adding an option in the `cli` to set the expiration time manually.


Although, the best approach here should be using JWT which encodes user info, coupled with redis, since using a RDBMS would unintentionally add write overhead.



### Test Logs
<!-- Please submit test logs to confirm everything is working. -->
```
========================== test session starts ===========================
platform linux -- Python 3.6.7, pytest-4.0.2, py-1.7.0, pluggy-0.8.0
rootdir: /home/invinciblycool/Documents/Github-projects/hydrus, inifile:
collected 51 items                                                       

hydrus/tests/test_app.py ................                          [ 31%]
hydrus/tests/test_auth.py ..........                               [ 50%]
hydrus/tests/test_crud.py ............                             [ 74%]
hydrus/tests/test_doc_writer.py ....                               [ 82%]
hydrus/tests/test_parser.py .........                              [100%]

======================= 51 passed in 1.42 seconds ========================
```
