### PR TITLE
Wrote test to check PEP8 compliance

### DIFF
--- a/hydrus/tests/test_pep8.py
+++ b/hydrus/tests/test_pep8.py
@@ -1,0 +1,22 @@
+"""Run PEP8 code format checker on all python files."""
+
+import unittest
+import pep8
+from subprocess import Popen, PIPE
+
+
+class TestCodeFormat(unittest.TestCase):
+    """Test class for Code Format"""
+
+    def test_pep8_conformance(self):
+        """Test that we conform to PEP8."""
+
+        print("Testing PEP8 conformance... ")
+        pep8style = pep8.StyleGuide(quiet=True)
+        with Popen("find . -type f -name '*.py'", shell=True, stdout=PIPE) as pipe:
+            py_files = [line.strip().decode('utf-8') for line in pipe.stdout]
+            pipe.stdout.close()
+        result = pep8style.check_files(py_files)
+        err_msg = "\n\tFound {} code style errors (and warnings)."
+        self.assertEqual(result.total_errors, 0,
+                         err_msg.format(result.total_errors))

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ Jinja2==2.10
 lifter==0.4.1
 MarkupSafe==1.0
 packaging==17.1
+pep8==1.7.1
 persisting-theory==0.2.1
 psycopg2==2.7.5
 pyparsing==2.2.0


### PR DESCRIPTION
To help developers adhere to PEP8 compliance requirement

<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #312 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
PEP8 is the convention laid down by the PSF. In essence it is a code style guide to be followed for achieving better programming practices in Python. This test helps find the existence of any non-conformant code in the entire repo.

### Test Logs
<!-- Please submit test logs to confirm everything is working. -->
```
Creating a temporary database...
going for create doc
Classes and properties added successfully.
Setting up Hydrus utilities...
Creating utilities context...
Setup done, running tests...
..../demoapi/anotherSingleClass
{'@context': '/demoapi/contexts/anotherSingleClass.jsonld', '@id': '/demoapi/', '@type': 'anotherSingleClass', 'Prop1': '4T4UG3'}
/demoapi/singleClass
{'@context': '/demoapi/contexts/singleClass.jsonld', '@id': '/demoapi/', '@type': 'singleClass', 'Prop1': '7ULYLV', 'Prop2': '3X21FS', 'dummyProp': '/demoapi/DcTest/7ba6070b-d2fa-4eea-a39f-6b4b6d5711cd', 'singleClassProp': '/demoapi/anotherSingleClass/'}
.............Creating a temporary datatbase...
Classes, Properties and Users added successfully.
Setting up Hydrus utilities...
Creating utilities context...
Setup done, running tests...
..........Creating a temporary datatbsse...
['User', 'Pet']
Pet
Classes and properties added successfully.
Setup done, running tests...
.........SELECT EXISTS (SELECT *
FROM instances
WHERE instances.id = ?) AS anon_1
.......Importing Open Api Documentation ..
......Method on path /pet/findByStatus already present !
Method on path /pet/findByTags already present !
Method on path /pet/{petId} already present !
Cannot parse path /pet/{petId} because no ref to local class provided
Cannot parse path /pet/{petId} because no ref to local class provided
Cannot parse path /store/inventory because no ref to local class provided
Cannot parse path /store/order/{orderId} because no ref to local class provided
Method on path /user/createWithArray already present !
Method on path /user/createWithList already present !
Cannot parse path /user/login because no ref to local class provided
Cannot parse path /user/logout because no ref to local class provided
Cannot parse path /user/{username} because no ref to local class provided
...Testing PEP8 conformance...
E
======================================================================
ERROR: test_pep8_conformance (hydrus.tests.test_pep8.TestCodeFormat)
Test that we conform to PEP8.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/devdutt/Projects/hydrus/hydrus/tests/test_pep8.py", line 19, in test_pep8_conformance
    result = pep8style.check_files([py_files])
  File "/home/devdutt/.local/share/virtualenvs/hydrus-yYdojHCv/lib/python3.6/site-packages/pep8.py", line 1840, in check_files
    if os.path.isdir(path):
  File "/home/devdutt/.local/share/virtualenvs/hydrus-yYdojHCv/lib/python3.6/genericpath.py", line 42, in isdir
    st = os.stat(s)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not list

----------------------------------------------------------------------
Ran 53 tests in 2.013s

FAILED (errors=1)
```

### Changes log
Implemented PEP8 unit-test by creating ./hydrus/tests/test_pep8.py file.

#### Added
<!-- Edit these points below to describe the new features added with this PR -->
- PEP8 conformance test to check code style

#### Changed
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
- pep8 dependency details within requirements.txt

#### Fixed
<!-- Edit these points below to describe the bug fixes made with this PR -->
NONE

#### Removed
<!-- Edit these points below to describe the removed features with this PR -->
NONE