### PR TITLE
Add 'with' keyword for file I/O

### DIFF
--- a/hydrus/parser/openapi_parser.py
+++ b/hydrus/parser/openapi_parser.py
@@ -537,6 +537,5 @@ if __name__ == "__main__":
             print(exc)
     hydra_doc = parse(doc)
 
-    f = open("../samples/hydra_doc_sample.py", "w")
-    f.write(dump_documentation(hydra_doc))
-    f.close()
+    with open("../samples/hydra_doc_sample.py", "w") as f:
+        f.write(dump_documentation(hydra_doc))

--- a/hydrus/samples/doc_writer_sample.py
+++ b/hydrus/samples/doc_writer_sample.py
@@ -171,6 +171,5 @@ if __name__ == "__main__":
     doc = doc.replace('true', '"true"')
     doc = doc.replace('false', '"false"')
     doc = doc.replace('null', '"null"')
-    f = open("doc_writer_sample_output.py", "w")
-    f.write(doc)
-    f.close()
+    with open("doc_writer_sample_output.py", "w") as f:
+        f.write(doc)


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #343 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Currently, file handling is done without `with` keyword, which in fact is dangerous because if an exception occurs before the call to `close()` then `close()` will not be called and the memory issues can occur, or the file can be corrupted.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


#### Changed
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
Used `with` to open files in place of directly calling `open()` function.
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
