### PR TITLE
Implementation of Read-Only, Write-Only and Required Properties

### DIFF
--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -95,15 +95,19 @@ def get(id_: str, type_: str, api_name: str, session: scoped_session,
         triples.GraphIIT.subject == id_).all()
 
     for data in data_IAC:
-        prop_name = session.query(properties).filter(
-            properties.id == data.predicate).one().name
+        prop = session.query(properties).filter(
+            properties.id == data.predicate).one()
+        if prop.writeonly:
+            continue
         class_name = session.query(RDFClass).filter(
             RDFClass.id == data.object_).one().name
-        object_template[prop_name] = class_name
+        object_template[prop.name] = class_name
 
     for data in data_III:
-        prop_name = session.query(properties).filter(
-            properties.id == data.predicate).one().name
+        prop = session.query(properties).filter(
+            properties.id == data.predicate).one()
+        if prop.writeonly:
+            continue
         instance = session.query(Instance).filter(
             Instance.id == data.object_).one()
         # Get class name for instance object
@@ -114,24 +118,26 @@ def get(id_: str, type_: str, api_name: str, session: scoped_session,
         for collection in doc.collections:
             if doc.collections[collection]["collection"].class_.path == inst_class_name:
                 nested_class_path = doc.collections[collection]["collection"].path
-                object_template[prop_name] = "/{}/{}/{}".format(
+                object_template[prop.name] = "/{}/{}/{}".format(
                     api_name, nested_class_path, instance.id)
                 break
 
         if nested_class_path == "":
-            object_template[prop_name] = "/{}/{}/".format(
+            object_template[prop.name] = "/{}/{}/".format(
                 api_name, inst_class_name)
 
     for data in data_IIT:
-        prop_name = session.query(properties).filter(
-            properties.id == data.predicate).one().name
+        prop = session.query(properties).filter(
+            properties.id == data.predicate).one()
+        if prop.writeonly:
+            continue
         terminal = session.query(Terminal).filter(
             Terminal.id == data.object_).one()
         try:
-            object_template[prop_name] = terminal.value
+            object_template[prop.name] = terminal.value
         except BaseException:
             # If terminal is none
-            object_template[prop_name] = ""
+            object_template[prop.name] = ""
     object_template["@type"] = rdf_class.name
 
     if path is not None:

--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -59,7 +59,7 @@ properties = with_polymorphic(BaseProperty, "*")
 
 
 def get(id_: str, type_: str, api_name: str, session: scoped_session,
-        path: str = None) -> Dict[str, str]:
+        path: str = None, for_update = False) -> Dict[str, str]:
     """Retrieve an Instance with given ID from the database [GET].
     :param id_: id of object to be fetched
     :param type_: type of object
@@ -101,7 +101,7 @@ def get(id_: str, type_: str, api_name: str, session: scoped_session,
     for data in data_IAC:
         prop = session.query(properties).filter(
             properties.id == data.predicate).one()
-        if prop.writeonly:
+        if not for_update and prop.writeonly:
             continue
         class_name = session.query(RDFClass).filter(
             RDFClass.id == data.object_).one().name
@@ -110,7 +110,7 @@ def get(id_: str, type_: str, api_name: str, session: scoped_session,
     for data in data_III:
         prop = session.query(properties).filter(
             properties.id == data.predicate).one()
-        if prop.writeonly:
+        if not for_update and prop.writeonly:
             continue
         instance = session.query(Instance).filter(
             Instance.id == data.object_).one()
@@ -133,7 +133,7 @@ def get(id_: str, type_: str, api_name: str, session: scoped_session,
     for data in data_IIT:
         prop = session.query(properties).filter(
             properties.id == data.predicate).one()
-        if prop.writeonly:
+        if not for_update and prop.writeonly:
             continue
         terminal = session.query(Terminal).filter(
             Terminal.id == data.object_).one()
@@ -585,7 +585,7 @@ def update(id_: str,
     :return: id of updated object
     """
     # Keep the object as fail safe
-    instance = get(id_=id_, type_=type_, session=session, api_name=api_name)
+    instance = get(id_=id_, type_=type_, session=session, api_name=api_name, for_update=True)
     instance.pop("@id")
     # Delete the old object
     delete(id_=id_, type_=type_, session=session)

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -3,7 +3,7 @@
 from sqlalchemy import create_engine, ForeignKey
 from sqlalchemy.sql import func
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime, Boolean
 from sqlalchemy.sql import func
 from typing import Any
 import datetime
@@ -68,6 +68,9 @@ class BaseProperty(Base):
         primary_key=True)
     name = Column(String, unique=True, nullable=False)
     type_ = Column(String)
+    readonly = Column(Boolean)
+    writeonly = Column(Boolean)
+    required = Column(Boolean)
 
     __mapper_args__ = {
         'polymorphic_on': type_,

--- a/hydrus/data/doc_parse.py
+++ b/hydrus/data/doc_parse.py
@@ -21,14 +21,14 @@ def get_classes(apidoc: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 def get_all_properties(classes: List[Dict[str, Any]]) -> Set[str]:
     """Get all the properties in the APIDocumentation."""
-    # properties = list()
+    properties = list()
     prop_names = set()  # type: Set[str]
     for class_ in classes:
         for prop in class_["supportedProperty"]:
             if prop["title"] not in prop_names:
                 prop_names.add(prop["title"])
-                # properties.append(prop)
-    return set(prop_names)
+                properties.append(prop)
+    return properties
 
 
 def insert_classes(classes: List[Dict[str, Any]],
@@ -64,8 +64,10 @@ def insert_classes(classes: List[Dict[str, Any]],
 def insert_properties(properties: Set[str],
                       session: scoped_session) -> Optional[Any]:
     """Insert all the properties as defined in the APIDocumentation into DB."""
-    prop_list = [BaseProperty(name=prop) for prop in properties
-                 if not session.query(exists().where(BaseProperty.name == prop)).scalar()]
+    prop_list = [BaseProperty(name=prop["title"], readonly=prop["readonly"],
+                              writeonly=prop["writeonly"], required=prop["required"])
+                 for prop in properties
+                 if not session.query(exists().where(BaseProperty.name == prop["title"])).scalar()]
     session.add_all(prop_list)
     session.commit()
     return None

--- a/hydrus/data/exceptions.py
+++ b/hydrus/data/exceptions.py
@@ -1,5 +1,5 @@
 """Exceptions for the crud operations."""
-from typing import Dict, Tuple, Union
+from typing import List, Dict, Tuple, Union
 
 
 class ClassNotFound(Exception):
@@ -127,3 +127,19 @@ class RequiredPropertyNotFound(Exception):
         """Return the HTTP response for the Exception."""
         return 400, {
             "message": "The required property {} not found".format(self.type_)}
+
+
+class InsertMultipleObjectsError(Exception):
+    """Error when insertion of multiple objects fails"""
+
+    def __init__(self, objects_: List[Dict[str, str]], message: str) -> None:
+        """Constructor"""
+        self.objects_ = objects_
+        self.message = message
+
+    def get_HTTP(self) -> Tuple[int, Dict[str, str]]:
+        """Return the HTTP response for the Exception."""
+        return 400, {
+            "message": self.message,
+            "objects": self.objects_
+        }

--- a/hydrus/data/exceptions.py
+++ b/hydrus/data/exceptions.py
@@ -114,3 +114,16 @@ class UserNotFound(Exception):
         """Return the HTTP response for the Exception."""
         return 400, {
             "message": "The User with ID {} is not a valid/defined User".format(self.id_)}
+
+
+class RequiredPropertyNotFound(Exception):
+    """Error when the object inserted does not have a required property"""
+
+    def __init__(self, type_: int) -> None:
+        """Constructor"""
+        self.type_ = type_
+
+    def get_HTTP(self) -> Tuple[int, Dict[str, str]]:
+        """Return the HTTP response for the Exception."""
+        return 400, {
+            "message": "The required property {} not found".format(self.type_)}

--- a/hydrus/data/exceptions.py
+++ b/hydrus/data/exceptions.py
@@ -119,7 +119,7 @@ class UserNotFound(Exception):
 class RequiredPropertyNotFound(Exception):
     """Error when the object inserted does not have a required property"""
 
-    def __init__(self, type_: int) -> None:
+    def __init__(self, type_: str) -> None:
         """Constructor"""
         self.type_ = type_
 
@@ -139,7 +139,21 @@ class InsertMultipleObjectsError(Exception):
 
     def get_HTTP(self) -> Tuple[int, Dict[str, str]]:
         """Return the HTTP response for the Exception."""
-        return 400, {
+        return 202, {
             "message": self.message,
             "objects": self.objects_
         }
+
+
+class ReadOnlyPropertyException(Exception):
+    """Error when the object to be updated has a readonly property"""
+
+    def __init__(self, type_: str) -> None:
+        """Constructor"""
+        self.type_ = type_
+
+    def get_HTTP(self) -> Tuple[int, Dict[str, str]]:
+        """Return the HTTP response for the Exception."""
+        return 400, {
+            "message": "The property {} is readonly".format(self.type_)}
+

--- a/hydrus/resources.py
+++ b/hydrus/resources.py
@@ -39,7 +39,10 @@ from hydrus.data.exceptions import (
     ClassNotFound,
     InstanceExists,
     PropertyNotFound,
-    InstanceNotFound)
+    InstanceNotFound,
+    RequiredPropertyNotFound,
+    InsertMultipleObjectsError)
+
 from hydrus.helpers import (
     set_response_headers,
     checkClassOp,
@@ -191,7 +194,7 @@ class Item(Resource):
                             "message": "Object with ID {} successfully added".format(object_id)}
                         return set_response_headers(
                             jsonify(response), headers=headers_, status_code=201)
-                    except (ClassNotFound, InstanceExists, PropertyNotFound) as e:
+                    except (ClassNotFound, InstanceExists, PropertyNotFound, RequiredPropertyNotFound) as e:
                         status_code, message = e.get_HTTP()
                         return set_response_headers(
                             jsonify(message), status_code=status_code)
@@ -315,7 +318,7 @@ class ItemCollection(Resource):
                                 "message": "Object with ID {} successfully added".format(object_id)}
                             return set_response_headers(
                                 jsonify(response), headers=headers_, status_code=201)
-                        except (ClassNotFound, InstanceExists, PropertyNotFound) as e:
+                        except (ClassNotFound, InstanceExists, PropertyNotFound, RequiredPropertyNotFound) as e:
                             status_code, message = e.get_HTTP()
                             return set_response_headers(
                                 jsonify(message), status_code=status_code)
@@ -338,7 +341,7 @@ class ItemCollection(Resource):
                             response = {"message": "Object successfully added"}
                             return set_response_headers(
                                 jsonify(response), headers=headers_, status_code=201)
-                        except (ClassNotFound, InstanceExists, PropertyNotFound) as e:
+                        except (ClassNotFound, InstanceExists, PropertyNotFound, RequiredPropertyNotFound) as e:
                             status_code, message = e.get_HTTP()
                             return set_response_headers(
                                 jsonify(message), status_code=status_code)
@@ -460,7 +463,7 @@ class Items(Resource):
                                 "message": "Object with ID {} successfully added".format(object_id)}
                             return set_response_headers(
                                 jsonify(response), headers=headers_, status_code=201)
-                        except (ClassNotFound, InstanceExists, PropertyNotFound) as e:
+                        except (ClassNotFound, InstanceExists, PropertyNotFound, InsertMultipleObjectsError) as e:
                             status_code, message = e.get_HTTP()
                             return set_response_headers(
                                 jsonify(message), status_code=status_code)

--- a/hydrus/resources.py
+++ b/hydrus/resources.py
@@ -41,7 +41,8 @@ from hydrus.data.exceptions import (
     PropertyNotFound,
     InstanceNotFound,
     RequiredPropertyNotFound,
-    InsertMultipleObjectsError)
+    InsertMultipleObjectsError,
+    ReadOnlyPropertyException)
 
 from hydrus.helpers import (
     set_response_headers,
@@ -154,7 +155,8 @@ class Item(Resource):
                         return set_response_headers(
                             jsonify(response), headers=headers_)
 
-                    except (ClassNotFound, InstanceNotFound, InstanceExists, PropertyNotFound) as e:
+                    except (ClassNotFound, InstanceNotFound, InstanceExists, PropertyNotFound,
+                            RequiredPropertyNotFound, ReadOnlyPropertyException) as e:
                         status_code, message = e.get_HTTP()
                         return set_response_headers(
                             jsonify(message), status_code=status_code)


### PR DESCRIPTION

Fixes #226 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Change logs
1. Changed the database schema to store read-only, write-only and required attributes of a property.
2. Added code for checking the validity of properties during crud operations.
3. Added Exceptions to handle errors related to it.

### Description
Feature to handle read-only, write-only and required attributes of the properties.

The following approach has been made:
1. The database schema has been changed. The read-only, write-only and required attributes of a property are stored in the database.
2. `crud.py` is responsible for checking the validity of properties during crud operations and to handle them accordingly.
3. During get operation, the properties that are write-only are omitted.
4. During insert operation, the object provided are checked for all required properties and exception is raised when any of it is missing.
5. During multiple insertion, only those objects are inserted which has all the required properties, the others are omitted and exception is raised.
6. During update, the object invokes the insert function with the parameter `to_update` set to `True`. This signals the latter to check for read-only properties and raise exception accordingly.
7. Three exceptions has been added. They are as follows - 
`RequiredPropertyNotFound` - When a required property of an object is missing during insert operations.
`InsertMultipleObjectError` - When any object has a missing required property, during insertion of multiple objects.
`ReadOnlyException` - When the object given by the user to update an existing object has a read-only property.

The following problem still persists -
1. `crud.py` uses `get_doc()` to access nested class paths, achieve segregation of objects and check for the required properties of objects. This is generally not a good design as `crud.py` should only be accessing the database. We might need to change the database schema in the future to store classes and their properties.
2. crud tests could not run as sample docs could not be passed on to `crud.py`

