### PR TITLE
FIX: placeholders found missing, placed properly

### DIFF
--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -562,9 +562,9 @@ def get_single(type_: str, api_name: str, session: scoped_session,
     object_ = get(instance.id, rdf_class.name,
                   session=session, api_name=api_name, path=path)
     if path is not None:
-        object_["@id"] = "/{}/".format(api_name, path)
+        object_["@id"] = "/{}/{}".format(api_name, path)
     else:
-        object_["@id"] = "/{}/".format(api_name, type_)
+        object_["@id"] = "/{}/{}".format(api_name, type_)
     return object_
 
 

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -53,9 +53,9 @@ def set_response_headers(resp: Response,
     for header in headers:
         resp.headers[list(header.keys())[0]] = header[list(header.keys())[0]]
     resp.headers['Content-type'] = ct
-    resp.headers['Link'] = '<{}{}/vocab>; rel='
-    '"http://www.w3.org/ns/hydra/core#apiDocumentation"'.format(
-            get_hydrus_server_url(), get_api_name())
+    link = "http://www.w3.org/ns/hydra/core#apiDocumentation"
+    resp.headers['Link'] = '<{}{}/vocab>; rel="{}"'.format(
+        get_hydrus_server_url(), get_api_name(), link)
     return resp
 
 

--- a/hydrus/parser/openapi_parser.py
+++ b/hydrus/parser/openapi_parser.py
@@ -235,7 +235,7 @@ def get_class_details(global_: Dict[str,
                                        write=True))
                 else:
                     global_[class_name]["prop_definition"].append(
-                        HydraClassProp("vocab:".format(prop), prop, required=flag,
+                        HydraClassProp("vocab:{}".format(prop), prop, required=flag,
                                        read=True, write=True))
             else:
                 global_[class_name]["prop_definition"].append(HydraClassProp(

--- a/hydrus/resources.py
+++ b/hydrus/resources.py
@@ -105,13 +105,11 @@ class Item(Resource):
                     api_name=get_api_name(),
                     session=get_session())
 
-                return set_response_headers(
-                    jsonify(hydrafy(response, path=path)))
+                return set_response_headers(jsonify(hydrafy(response, path=path)))
 
             except (ClassNotFound, InstanceNotFound) as e:
                 status_code, message = e.get_HTTP()
-                return set_response_headers(
-                    jsonify(message), status_code=status_code)
+                return set_response_headers(jsonify(message), status_code=status_code)
         abort(405)
 
     def post(self, id_: str, path: str) -> Response:
@@ -143,21 +141,17 @@ class Item(Resource):
                             type_=object_["@type"],
                             session=get_session(),
                             api_name=get_api_name())
-                        headers_ = [
-                            {"Location": "{}/{}/{}".format(
+                        headers_ = [{"Location": "{}{}/{}/{}".format(
                                 get_hydrus_server_url(), get_api_name(), path, object_id)}]
                         response = {
                             "message": "Object with ID {} successfully updated".format(object_id)}
-                        return set_response_headers(
-                            jsonify(response), headers=headers_)
+                        return set_response_headers(jsonify(response), headers=headers_)
 
                     except (ClassNotFound, InstanceNotFound, InstanceExists, PropertyNotFound) as e:
                         status_code, message = e.get_HTTP()
-                        return set_response_headers(
-                            jsonify(message), status_code=status_code)
+                        return set_response_headers(jsonify(message), status_code=status_code)
 
-            return set_response_headers(
-                jsonify({400: "Data is not valid"}), status_code=400)
+            return set_response_headers(jsonify({400: "Data is not valid"}), status_code=400)
 
         abort(405)
 
@@ -182,10 +176,8 @@ class Item(Resource):
                 if object_["@type"] == obj_type:
                     try:
                         # Add the object with given ID
-                        object_id = crud.insert(
-                            object_=object_, id_=id_, session=get_session())
-                        headers_ = [
-                            {"Location": "{}/{}/{}".format(
+                        object_id = crud.insert(object_=object_, id_=id_, session=get_session())
+                        headers_ = [{"Location": "{}{}/{}/{}".format(
                                 get_hydrus_server_url(), get_api_name(), path, object_id)}]
                         response = {
                             "message": "Object with ID {} successfully added".format(object_id)}
@@ -193,11 +185,9 @@ class Item(Resource):
                             jsonify(response), headers=headers_, status_code=201)
                     except (ClassNotFound, InstanceExists, PropertyNotFound) as e:
                         status_code, message = e.get_HTTP()
-                        return set_response_headers(
-                            jsonify(message), status_code=status_code)
+                        return set_response_headers(jsonify(message), status_code=status_code)
 
-            return set_response_headers(
-                jsonify({400: "Data is not valid"}), status_code=400)
+            return set_response_headers(jsonify({400: "Data is not valid"}), status_code=400)
 
         abort(405)
 
@@ -221,8 +211,7 @@ class Item(Resource):
 
             except (ClassNotFound, InstanceNotFound) as e:
                 status_code, message = e.get_HTTP()
-                return set_response_headers(
-                    jsonify(message), status_code=status_code)
+                return set_response_headers(jsonify(message), status_code=status_code)
 
         abort(405)
 
@@ -247,13 +236,11 @@ class ItemCollection(Resource):
                     # Get collection details from the database
                     response = crud.get_collection(
                         get_api_name(), collection.class_.title, session=get_session(), path=path)
-                    return set_response_headers(
-                        jsonify(hydrafy(response, path=path)))
+                    return set_response_headers(jsonify(hydrafy(response, path=path)))
 
                 except ClassNotFound as e:
                     status_code, message = e.get_HTTP()
-                    return set_response_headers(
-                        jsonify(message), status_code=status_code)
+                    return set_response_headers(jsonify(message), status_code=status_code)
 
             # If class is supported
             elif path in get_doc().parsed_classes and "{}Collection".format(path) not in get_doc(
@@ -265,13 +252,11 @@ class ItemCollection(Resource):
                         api_name=get_api_name(),
                         session=get_session(),
                         path=path)
-                    return set_response_headers(
-                        jsonify(hydrafy(response, path=path)))
+                    return set_response_headers(jsonify(hydrafy(response, path=path)))
 
                 except (ClassNotFound, InstanceNotFound) as e:
                     status_code, message = e.get_HTTP()
-                    return set_response_headers(
-                        jsonify(message), status_code=status_code)
+                    return set_response_headers(jsonify(message), status_code=status_code)
 
         abort(endpoint_['status'])
 
@@ -306,10 +291,8 @@ class ItemCollection(Resource):
                         # collection
                         try:
                             # Insert object and return location in Header
-                            object_id = crud.insert(
-                                object_=object_, session=get_session())
-                            headers_ = [
-                                {"Location": "{}/{}/{}".format(
+                            object_id = crud.insert(object_=object_, session=get_session())
+                            headers_ = [{"Location": "{}{}/{}/{}".format(
                                     get_hydrus_server_url(), get_api_name(), path, object_id)}]
                             response = {
                                 "message": "Object with ID {} successfully added".format(object_id)}
@@ -317,11 +300,9 @@ class ItemCollection(Resource):
                                 jsonify(response), headers=headers_, status_code=201)
                         except (ClassNotFound, InstanceExists, PropertyNotFound) as e:
                             status_code, message = e.get_HTTP()
-                            return set_response_headers(
-                                jsonify(message), status_code=status_code)
+                            return set_response_headers(jsonify(message), status_code=status_code)
 
-                return set_response_headers(
-                    jsonify({400: "Data is not valid"}), status_code=400)
+                return set_response_headers(jsonify({400: "Data is not valid"}), status_code=400)
 
             elif path in get_doc().parsed_classes and "{}Collection".format(path) not in get_doc(
             ).collections:
@@ -330,21 +311,17 @@ class ItemCollection(Resource):
                 if object_["@type"] == obj_type:
                     if validObject(object_):
                         try:
-                            object_id = crud.insert(
-                                object_=object_, session=get_session())
-                            headers_ = [
-                                {"Location": "{}/{}/".format(
+                            object_id = crud.insert(object_=object_, session=get_session())
+                            headers_ = [{"Location": "{}{}/{}/".format(
                                     get_hydrus_server_url(), get_api_name(), path)}]
                             response = {"message": "Object successfully added"}
                             return set_response_headers(
                                 jsonify(response), headers=headers_, status_code=201)
                         except (ClassNotFound, InstanceExists, PropertyNotFound) as e:
                             status_code, message = e.get_HTTP()
-                            return set_response_headers(
-                                jsonify(message), status_code=status_code)
+                            return set_response_headers(jsonify(message), status_code=status_code)
 
-                return set_response_headers(
-                    jsonify({400: "Data is not valid"}), status_code=400)
+                return set_response_headers(jsonify({400: "Data is not valid"}), status_code=400)
 
         abort(endpoint_['status'])
 
@@ -373,21 +350,17 @@ class ItemCollection(Resource):
                                 session=get_session(),
                                 api_name=get_api_name(),
                                 path=path)
-                            headers_ = [
-                                {"Location": "{}/{}/".format(
+                            headers_ = [{"Location": "{}{}/{}/".format(
                                     get_hydrus_server_url(), get_api_name(), path)}]
                             response = {
                                 "message": "Object successfully updated"}
-                            return set_response_headers(
-                                jsonify(response), headers=headers_)
+                            return set_response_headers(jsonify(response), headers=headers_)
                         except (ClassNotFound, InstanceNotFound,
                                 InstanceExists, PropertyNotFound) as e:
                             status_code, message = e.get_HTTP()
-                            return set_response_headers(
-                                jsonify(message), status_code=status_code)
+                            return set_response_headers(jsonify(message), status_code=status_code)
 
-                return set_response_headers(
-                    jsonify({400: "Data is not valid"}), status_code=400)
+                return set_response_headers(jsonify({400: "Data is not valid"}), status_code=400)
 
         abort(endpoint_['status'])
 
@@ -414,8 +387,7 @@ class ItemCollection(Resource):
                     return set_response_headers(jsonify(response))
                 except (ClassNotFound, InstanceNotFound) as e:
                     status_code, message = e.get_HTTP()
-                    return set_response_headers(
-                        jsonify(message), status_code=status_code)
+                    return set_response_headers(jsonify(message), status_code=status_code)
         abort(endpoint_['status'])
 
 
@@ -453,8 +425,7 @@ class Items(Resource):
                             # Insert object and return location in Header
                             object_id = crud.insert_multiple(
                                 objects_=object_, session=get_session(), id_=int_list)
-                            headers_ = [
-                                {"Location": "{}/{}/{}".format(
+                            headers_ = [{"Location": "{}{}/{}/{}".format(
                                     get_hydrus_server_url(), get_api_name(), path, object_id)}]
                             response = {
                                 "message": "Object with ID {} successfully added".format(object_id)}
@@ -462,11 +433,9 @@ class Items(Resource):
                                 jsonify(response), headers=headers_, status_code=201)
                         except (ClassNotFound, InstanceExists, PropertyNotFound) as e:
                             status_code, message = e.get_HTTP()
-                            return set_response_headers(
-                                jsonify(message), status_code=status_code)
+                            return set_response_headers(jsonify(message), status_code=status_code)
 
-                return set_response_headers(
-                    jsonify({400: "Data is not valid"}), status_code=400)
+                return set_response_headers(jsonify({400: "Data is not valid"}), status_code=400)
 
         abort(endpoint_['status'])
 
@@ -486,16 +455,14 @@ class Items(Resource):
             # Check if class_type supports PUT operation
             try:
                 # Delete the Item with ID == id_
-                crud.delete_multiple(
-                    int_list, class_type, session=get_session())
+                crud.delete_multiple(int_list, class_type, session=get_session())
                 response = {
                     "message": "Object with ID {} successfully deleted".format(int_list.split(','))}
                 return set_response_headers(jsonify(response))
 
             except (ClassNotFound, InstanceNotFound) as e:
                 status_code, message = e.get_HTTP()
-                return set_response_headers(
-                    jsonify(message), status_code=status_code)
+                return set_response_headers(jsonify(message), status_code=status_code)
 
         abort(405)
 
@@ -508,13 +475,11 @@ class Contexts(Resource):
         # Check for collection
         if category in get_doc().collections:
             # type: Union[Dict[str,Any],Dict[int,str]]
-            response = {
-                "@context": get_doc().collections[category]["context"].generate()}
+            response = {"@context": get_doc().collections[category]["context"].generate()}
             return set_response_headers(jsonify(response))
         # Check for non collection class
         elif category in get_doc().parsed_classes:
-            response = {
-                "@context": get_doc().parsed_classes[category]["context"].generate()}
+            response = {"@context": get_doc().parsed_classes[category]["context"].generate()}
             return set_response_headers(jsonify(response))
         else:
             response = {404: "NOT FOUND"}


### PR DESCRIPTION
Some placeholders within str.format() expression were found missing and have been properly placed.

<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #303 and is directly on master to fix a bug created in a merged commit.

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
This PR is to solve an issue that was brought in due to the lack of placeholders within the str.format() function calls in the resources.py file.
<!-- Describe about what this PR does, previous state and new state of the output -->

### Change logs
Fix missing {} placeholders within str.format() expressions.

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
