### PR TITLE
Refactoring validation keys in doc_maker

### DIFF
--- a/hydrus/hydraspec/doc_maker.py
+++ b/hydrus/hydraspec/doc_maker.py
@@ -30,7 +30,7 @@ prop_keys = {
     "required": True
 }
 
-operation_keys = {
+op_keys = {
     "title": False,
     "method": False,
     "expects": True,
@@ -45,6 +45,21 @@ status_keys = {
     "returns": True,
     "possibleStatus": False
 }
+
+
+def get_keys(body_type: str) -> Dict[str: bool]:
+    """Function returns the appropriate dictionary according to body type
+    :param body_type: the type of dict we need
+    :return: the required dictionary payload
+    """
+    key_map = {
+        "doc": doc_keys,
+        "class_dict": class_keys,
+        "supported_prop": prop_keys,
+        "supported_op": op_keys,
+        "possible_status": status_keys
+    }
+    return key_map[body_type]
 
 
 def error_mapping(body: str = None) -> str:

--- a/hydrus/hydraspec/doc_maker.py
+++ b/hydrus/hydraspec/doc_maker.py
@@ -130,11 +130,7 @@ def create_doc(doc: Dict[str, Any], HYDRUS_SERVER_URL: str = None,
             "The '@id' of the Documentation must be of the form:\n"
             "'[protocol] :// [base url] / [entrypoint] / vocab'")
 
-    # TODO doc_keys
-
-    result = {}
-    for k, literal in doc_keys.items():
-        result[k] = get_transformed_keys(doc, k, "doc", literal)
+    result = get_transformed_keys(doc, "doc")
 
     # EntryPoint object
     # getEntrypoint checks if all classes have @id
@@ -186,11 +182,7 @@ def create_class(
     if match_obj:
         id_ = match_obj.group(1)
 
-    # TODO class_keys
-
-    result = {}
-    for k, literal in doc_keys.items():
-        result[k] = get_transformed_keys(class_dict, k, "class_dict", literal)
+    result = get_transformed_keys(class_dict, "class_dict")
 
     # See if class_dict is a Collection Class
     # type: Union[Match[Any], bool]
@@ -278,13 +270,8 @@ def convert_literal(literal: Any) -> Optional[Union[bool, str]]:
 def create_property(supported_prop: Dict[str, Any]) -> HydraClassProp:
     """Create a HydraClassProp object from the supportedProperty."""
     # Syntax checks
+    result = get_transformed_keys(supported_prop, "supported_prop")
 
-    # TODO prop_keys
-
-    result = {}
-    for k, literal in doc_keys.items():
-        result[k] = get_transformed_keys(
-            supported_prop, k, "supported_prop", literal)
     # Create the HydraClassProp object
     prop = HydraClassProp(result["property"], result["title"], required=result["required"],
                           read=result["readonly"], write=result["writeonly"])
@@ -367,12 +354,7 @@ def collection_in_endpoint(
 def create_operation(supported_op: Dict[str, Any]) -> HydraClassOp:
     """Create a HyraClassOp object from the supportedOperation."""
     # Syntax checks
-
-    # TODO op_keys
-
-    result = {}
-    for k, literal in doc_keys.items():
-        result[k] = get_transformed_keys(supported_op, k, "supported_op", literal)
+    result = get_transformed_keys(supported_op, "supported_op")
 
     # Create the HydraClassOp object
     op_ = HydraClassOp(result["title"], result["method"],
@@ -383,13 +365,8 @@ def create_operation(supported_op: Dict[str, Any]) -> HydraClassOp:
 def create_status(possible_status: Dict[str, Any]) -> HydraStatus:
     """Create a HydraStatus object from the possibleStatus."""
     # Syntax checks
+    result = get_transformed_keys(possible_status, "possible_status")
 
-    # TODO status keys
-
-    result = {}
-    for k, literal in doc_keys.items():
-        result[k] = get_transformed_keys(
-            possible_status, k, "possible_status", literal)
     # Create the HydraStatus object
     status = HydraStatus(result["statusCode"],
                          result["title"], result["description"])

--- a/hydrus/hydraspec/doc_maker.py
+++ b/hydrus/hydraspec/doc_maker.py
@@ -7,7 +7,7 @@ from hydrus.hydraspec.doc_writer import HydraDoc, HydraClass, HydraClassProp, Hy
 from hydrus.hydraspec.doc_writer import HydraStatus
 from typing import Any, Dict, Match, Optional, Tuple, Union
 
-doc_keys = {
+DOC_KEYS = {
     "description": False,
     "title": False,
     "supportedClass": False,
@@ -15,14 +15,14 @@ doc_keys = {
     "possibleStatus": False
 }
 
-class_keys = {
+CLASS_KEYS = {
     "supportedProperty": False,
     "title": False,
     "description": False,
     "supportedOperation": False
 }
 
-prop_keys = {
+PROP_KEYS = {
     "property": False,
     "title": False,
     "readonly": True,
@@ -30,7 +30,7 @@ prop_keys = {
     "required": True
 }
 
-op_keys = {
+OP_KEYS = {
     "title": False,
     "method": False,
     "expects": True,
@@ -38,7 +38,7 @@ op_keys = {
     "possibleStatus": False
 }
 
-status_keys = {
+STATUS_KEYS = {
     "title": False,
     "method": False,
     "expects": True,
@@ -53,11 +53,11 @@ def get_keys(body_type: str) -> Dict[str, bool]:
     :return: the required dictionary payload
     """
     key_map = {
-        "doc": doc_keys,
-        "class_dict": class_keys,
-        "supported_prop": prop_keys,
-        "supported_op": op_keys,
-        "possible_status": status_keys
+        "doc": DOC_KEYS,
+        "class_dict": CLASS_KEYS,
+        "supported_prop": PROP_KEYS,
+        "supported_op": OP_KEYS,
+        "possible_status": STATUS_KEYS
     }
     return key_map[body_type]
 

--- a/hydrus/hydraspec/doc_maker.py
+++ b/hydrus/hydraspec/doc_maker.py
@@ -7,6 +7,45 @@ from hydrus.hydraspec.doc_writer import HydraDoc, HydraClass, HydraClassProp, Hy
 from hydrus.hydraspec.doc_writer import HydraStatus
 from typing import Any, Dict, Match, Optional, Tuple, Union
 
+doc_keys = {
+    "description": False,
+    "title": False,
+    "supportedClass": False,
+    "@context": False,
+    "possibleStatus": False
+}
+
+class_keys = {
+    "supportedProperty": False,
+    "title": False,
+    "description": False,
+    "supportedOperation": False
+}
+
+prop_keys = {
+    "property": False,
+    "title": False,
+    "readonly": True,
+    "writeonly": True,
+    "required": True
+}
+
+operation_keys = {
+    "title": False,
+    "method": False,
+    "expects": True,
+    "returns": True,
+    "possibleStatus": False
+}
+
+status_keys = {
+    "title": False,
+    "method": False,
+    "expects": True,
+    "returns": True,
+    "possibleStatus": False
+}
+
 
 def error_mapping(body: str = None) -> str:
     """Function returns starting error message based on its body type.
@@ -72,13 +111,9 @@ def create_doc(doc: Dict[str, Any], HYDRUS_SERVER_URL: str = None,
         raise SyntaxError(
             "The '@id' of the Documentation must be of the form:\n"
             "'[protocol] :// [base url] / [entrypoint] / vocab'")
-    doc_keys = {
-        "description": False,
-        "title": False,
-        "supportedClass": False,
-        "@context": False,
-        "possibleStatus": False
-    }
+
+    # TODO doc_keys
+
     result = {}
     for k, literal in doc_keys.items():
         result[k] = input_key_check(doc, k, "doc", literal)
@@ -133,12 +168,7 @@ def create_class(
     if match_obj:
         id_ = match_obj.group(1)
 
-    doc_keys = {
-        "supportedProperty": False,
-        "title": False,
-        "description": False,
-        "supportedOperation": False
-    }
+    # TODO class_keys
 
     result = {}
     for k, literal in doc_keys.items():
@@ -231,13 +261,8 @@ def create_property(supported_prop: Dict[str, Any]) -> HydraClassProp:
     """Create a HydraClassProp object from the supportedProperty."""
     # Syntax checks
 
-    doc_keys = {
-        "property": False,
-        "title": False,
-        "readonly": True,
-        "writeonly": True,
-        "required": True
-    }
+    # TODO prop_keys
+
     result = {}
     for k, literal in doc_keys.items():
         result[k] = input_key_check(
@@ -324,13 +349,9 @@ def collection_in_endpoint(
 def create_operation(supported_op: Dict[str, Any]) -> HydraClassOp:
     """Create a HyraClassOp object from the supportedOperation."""
     # Syntax checks
-    doc_keys = {
-        "title": False,
-        "method": False,
-        "expects": True,
-        "returns": True,
-        "possibleStatus": False
-    }
+
+    # TODO op_keys
+
     result = {}
     for k, literal in doc_keys.items():
         result[k] = input_key_check(supported_op, k, "supported_op", literal)
@@ -344,11 +365,9 @@ def create_operation(supported_op: Dict[str, Any]) -> HydraClassOp:
 def create_status(possible_status: Dict[str, Any]) -> HydraStatus:
     """Create a HydraStatus object from the possibleStatus."""
     # Syntax checks
-    doc_keys = {
-        "title": False,
-        "statusCode": False,
-        "description": True
-    }
+
+    # TODO status keys
+
     result = {}
     for k, literal in doc_keys.items():
         result[k] = input_key_check(

--- a/hydrus/hydraspec/doc_maker.py
+++ b/hydrus/hydraspec/doc_maker.py
@@ -47,7 +47,7 @@ status_keys = {
 }
 
 
-def get_keys(body_type: str) -> Dict[str: bool]:
+def get_keys(body_type: str) -> Dict[str, bool]:
     """Function returns the appropriate dictionary according to body type
     :param body_type: the type of dict we need
     :return: the required dictionary payload


### PR DESCRIPTION
Fixes #348

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
Currently the hard-coded dictionaries for key validation are present inside function definitions. Being a constant, it should be declared globally according to PEP-8 standards. The PR makes them all global
and creates a function to map them with `body_type`. 

### Change logs
1. Declare the keys as global
2. Create `get_keys` to map those keys with `body_type`
3. Changed and renamed `input_key_check` function to perform all key validations and raise error accordingly

The keys could also be moved to a new file that can serve as a template provider and can be accessed from there.