### PR TITLE
Solving requeriments problems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ SQLAlchemy==1.2.10
 thespian==3.9.2
 Werkzeug==0.14.1
 PyYAML==4.2b1
--e git+https://github.com/HTTP-APIs/hydra-python-core@v0.1#egg=hydra_python_core
--e git+https://github.com/HTTP-APIs/hydra-openapi-parser@0.1.1#egg=hydra_openapi_parser
+git+https://github.com/HTTP-APIs/hydra-python-core@v0.1#egg=hydra_python_core
+git+https://github.com/HTTP-APIs/hydra-openapi-parser@0.1.1#egg=hydra_openapi_parser


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
When I tried to build and run the docker image, I got the following error:

ImportError: No module named 'hydra_python_core'

To solve it, is just change the installation of the hydra_python_core and the hydra_openapi_parser.


### Change logs

Edit the lines on requirements.txt that install the hydra dependences

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
