### PR TITLE
Rewrite cli.py and move tests into repo root

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -97,9 +97,8 @@ def startserver(adduser: Tuple, api: str, auth: bool, dburl: str,
                 with open(hydradoc, 'r') as f:
                     doc = json.load(f)
             elif hydradoc_format == 'py':
-                doc = SourceFileLoader("doc",
-                                       "./examples/drones/doc.py")\
-                    .load_module().doc
+                doc = SourceFileLoader(
+                    "doc", "./examples/drones/doc.py").load_module().doc
             elif hydradoc_format == 'yaml':
                 with open(hydradoc, 'r') as stream:
                     doc = parse(yaml.load(stream))
@@ -116,9 +115,12 @@ def startserver(adduser: Tuple, api: str, auth: bool, dburl: str,
             apidoc = doc_maker.create_doc(api_document,
                                           HYDRUS_SERVER_URL, API_NAME)
     else:
-        click.echo("No hydradoc specified, using sample hydradoc as default.")
-        apidoc = doc_maker.create_doc(api_document,
-                                      HYDRUS_SERVER_URL, API_NAME)
+        click.echo("No hydradoc specified, using sample hydradoc as default.\n"
+                   "For creating api documentation see this "
+                   "https://www.hydraecosystem.org/01-Usage.html#newdoc\n"
+                   "You can find the example used in examples/drones/doc.py")
+        apidoc = doc_maker.create_doc(
+            api_document, HYDRUS_SERVER_URL, API_NAME)
 
     # Start a session with the DB and create all classes needed by the APIDoc
     session = scoped_session(sessionmaker(bind=engine))

--- a/tests/test_pep8.py
+++ b/tests/test_pep8.py
@@ -10,13 +10,16 @@ class Pep8Test(unittest.TestCase):
 
     def test_pep8(self):
         """Test method to check PEP8 compliance over the entire project."""
-        print(dirname(dirname(abspath(__file__))))
+        self.file_structure = dirname(dirname(abspath(__file__)))
+        print("Testing for PEP8 compliance of python files in {}".format(
+            self.file_structure))
         style = pep8.StyleGuide()
         style.options.max_line_length = 100  # Set this to desired maximum line length
         filenames = []
         # Set this to desired folder location
-        for root, _, files in os.walk(dirname(dirname(abspath(__file__)))):
-            python_files = [f for f in files if f.endswith('.py')]
+        for root, _, files in os.walk(self.file_structure):
+            python_files = [f for f in files if f.endswith(
+                '.py') and f.find("examples") == 0]
             for file in python_files:
                 if len(root.split('samples')) != 2:     # Ignore samples directory
                     filename = '{0}/{1}'.format(root, file)
@@ -24,6 +27,7 @@ class Pep8Test(unittest.TestCase):
         check = style.check_files(filenames)
         self.assertEqual(check.total_errors, 0, 'PEP8 style errors: %d' %
                          check.total_errors)
+
 
 if __name__ == '__main__':
     print("Starting tests ..")


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes parts of #361

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
I have moved the tests out of the module and made changes to the cli interface. Grammatical in nature as well.
<!-- Describe about what this PR does, previous state and new state of the output -->

### Change logs
Test for PEP8 compliance moved out of `hydrus/`. It also ignores the files with `examples`, but this can changed as required. Side Note: `examples/` have a lot of non-compliant code. My reasoning behind is this is that Hydrus' CLI script doesn't come under the ambit of the test_pep8.py as implemented now.
<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
