### PR TITLE
Remove restrictions to libraries version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ appdirs==1.4.3
 blinker==1.4
 click==6.7
 Flask==1.0.2
-Flask-Cors==3.0.6
-Flask-RESTful==0.3.6
+Flask-Cors
+Flask-RESTful
 gevent==1.3.5
 greenlet==0.4.13
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2
 lifter==0.4.1
 MarkupSafe==1.0
 packaging==17.1
@@ -19,9 +19,9 @@ pyparsing==2.2.0
 python-dateutil==2.7.3
 pytz==2018.5
 six==1.11.0
-SQLAlchemy==1.2.10
+SQLAlchemy
 thespian==3.9.2
-Werkzeug==0.14.1
+Werkzeug
 PyYAML==5.1
 git+https://github.com/HTTP-APIs/hydra-python-core@v0.1#egg=hydra_python_core
 git+https://github.com/HTTP-APIs/hydra-openapi-parser@0.1.1#egg=hydra_openapi_parser

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ six==1.11.0
 SQLAlchemy
 thespian==3.9.2
 Werkzeug
-PyYAML==5.1
+PyYAML
 git+https://github.com/HTTP-APIs/hydra-python-core@v0.1#egg=hydra_python_core
 git+https://github.com/HTTP-APIs/hydra-openapi-parser@0.1.1#egg=hydra_openapi_parser


### PR DESCRIPTION
Fix vulnerabilities in some libraries.

@xadahiya @chrizandr please fix the versions in demos running in the cloud.

**It is an anti-pattern to pin all the requirements. Pinned requirements shall be kept to minimal.**

Some cases to keep a library pinned:
* unstable API
* not security-related/injection-prone