### PR TITLE
Add mechanism to retrieve nested collections

### DIFF
--- a/hydrus/app_factory.py
+++ b/hydrus/app_factory.py
@@ -3,7 +3,7 @@ from flask_cors import CORS
 from flask_restful import Api
 
 from hydrus.resources import (Index, Vocab, Contexts, Entrypoint,
-                              ItemCollection, Item, Items)
+                              ItemCollection, NestedCollection, Item, Items)
 
 
 def app_factory(api_name: str = "api") -> Flask:
@@ -38,5 +38,9 @@ def app_factory(api_name: str = "api") -> Flask:
         "/{}/<string:path>/add/<int_list>".format(api_name),
         "/{}/<string:path>/add".format(api_name),
         "/{}/<string:path>/delete/<int_list>".format(api_name))
+    api.add_resource(
+        NestedCollection,
+        "/{}/<string:collection_type>/<uuid:id_>/<string:nested_collection_type>".format(api_name),
+        endpoint="nested_collection")
 
     return app

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -53,6 +53,7 @@ class Instance(Base):
     type_ = Column(String, ForeignKey("classes.id"), nullable=True)
     created = Column('created', DateTime, default=func.now())
     last_modified = Column('last_modified', DateTime, onupdate=func.now())
+    children = Column(String, default=None)
 
 
 class BaseProperty(Base):

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -166,6 +166,9 @@ def finalize_response(class_type: str, obj: Dict[str, Any]) -> Dict[str, Any]:
             obj.pop(prop.title, None)
         elif 'vocab:' in prop.prop:
             prop_class = prop.prop.replace("vocab:", "")
+            if prop_class in get_doc().collections:
+                obj[prop.title] = obj["@id"] + "/" + prop_class
+                continue
             nested_path, is_collection = get_nested_class_path(prop_class)
             if is_collection:
                 id = obj[prop.title]
@@ -202,6 +205,8 @@ def generate_iri_mappings(class_type: str, template: str, skip_nested: bool =Fal
     ).parsed_classes[class_type]["class"].supportedProperty:
         if "vocab:" in supportedProp.prop and skip_nested is False:
             prop_class = supportedProp.prop.replace("vocab:", "")
+            if prop_class in get_doc().collections:
+                continue
             template, template_mapping, skip_delimiter = generate_iri_mappings(prop_class, template, skip_nested=True,
                                                                                skip_delimiter=skip_delimiter,
                                                                                parent_prop_name=supportedProp.title,

--- a/hydrus/samples/hydra_doc_sample.py
+++ b/hydrus/samples/hydra_doc_sample.py
@@ -119,10 +119,10 @@ doc = {
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://schema.org/identifier",
+                    "property": "vocab:Drone",
                     "readonly": "false",
                     "required": "true",
-                    "title": "DroneID",
+                    "title": "DroneURI",
                     "writeonly": "false"
                 }
             ],
@@ -471,6 +471,14 @@ doc = {
                     "readonly": "false",
                     "required": "true",
                     "title": "DroneState",
+                    "writeonly": "false"
+                },
+{
+                    "@type": "SupportedProperty",
+                    "property": "vocab:StateCollection",
+                    "readonly": "false",
+                    "required": "false",
+                    "title": "Previous_states",
                     "writeonly": "false"
                 },
                 {


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #386 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Uses the approach suggested by @xadahiya at #386 to store a stringified list of children ids and internally uses  parent_id to update those lists.

There are a couple of issues which needs to be discussed.
1) **Identifying parent-child relationships**
When a new item is added to the child collection(`CommentCollection`) we need to identify parent class, which is quite easily done by searching for a class which has `vocab:CommentCollection` as `property`. But it is hard to identify the field which contains the `id` of the parent class. I think we can't simply use `schema.org/identifier` as it might be used to describe any other kind of id. 
To tackle it temporarily so I can move ahead with other parts of implementation I am having the `property` predicate of ParentURI supportedProperty set to the parent class(for example Comment class's issue_id field will have `vocab:Issue` as property. But this parent_id/uri field might only contain an id or a URI, but by property value `vocab:Issue` it seems the whole object is being sent when creating new Comment(As `State` object is contained in the `Drone` object while creation.) Line 322-355 in resources.py uses this to identify field which contains parent_id. It works well but it is not semantically correct. If ApiDoc maker always uses schema.org/parentItem or some other value as `property` value of parent_id field then I can avoid what I am doing right now and can easily identify which field is the `parent_id` field.(crud_test is failing while creating dummy_objects because of these new additions in the sample doc, I'll adapt tests when we some concrete solution to this problem.)
So basically the question is *how hydrus finds out which field of received objects contains parent_id?*
2) **Current sample ApiDoc does not have any such parent-nestedCollection realtions**
To test the mechanism I added a new field in Drone class which has `StateCollection` as property. We might want to have some other more meaningful way to add such a relationship or have another sample ApiDoc with such a relationship.


Other straight-forward tasks to be done:
1. Adding pagination and serch over nestedCollection.
2. Adding tests.
### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
