### PR TITLE
Add mechanism to support client-controlled pagination

### DIFF
--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -520,7 +520,7 @@ def get_collection(API_NAME: str,
                    session: scoped_session,
                    paginate: bool,
                    page_size: int,
-                   search_params: Dict[str, Any] = None,
+                   search_params: Dict[str, Any]=None,
                    path: str = None) -> Dict[str, Any]:
     """Retrieve a type of collection from the database.
     :param API_NAME: api name specified while starting server
@@ -567,8 +567,10 @@ def get_collection(API_NAME: str,
     result_length = len(filtered_instances)
     try:
         # To paginate, calculate offset and page_limit values for pagination of search results
-        page, page_size, offset = pre_process_pagination_parameters(search_params=search_params, paginate=paginate,
-                                                                    page_size=page_size, result_length=result_length)
+        page, page_size, offset = pre_process_pagination_parameters(search_params=search_params,
+                                                                    paginate=paginate,
+                                                                    page_size=page_size,
+                                                                    result_length=result_length)
     except (IncompatibleParameters, PageNotFound, OffsetOutOfRange):
         raise
     current_page_size = page_size
@@ -582,7 +584,10 @@ def get_collection(API_NAME: str,
             }
         else:
             object_template = {
-                "@id": "/{}/{}Collection/{}".format(API_NAME, type_, filtered_instances[i].id), "@type": type_}
+                "@id": "/{}/{}Collection/{}".format(API_NAME, type_,
+                                                    filtered_instances[i].id),
+                "@type": type_
+            }
         collection_template["members"].append(object_template)
 
     # If pagination is disabled then stop and return the collection template
@@ -605,8 +610,8 @@ def get_collection(API_NAME: str,
     else:
         paginate_param = "page"
     attach_hydra_view(collection_template=collection_template, paginate_param=paginate_param,
-                      result_length=result_length, iri=recreated_iri, page_size=page_size, offset=offset,
-                      page=page, last=last)
+                      result_length=result_length, iri=recreated_iri, page_size=page_size,
+                      offset=offset, page=page, last=last)
     return collection_template
 
 
@@ -768,14 +773,16 @@ def recreate_iri(API_NAME: str, path: str, search_params: Dict[str, Any]) -> str
     """
     iri = "/{}/{}?".format(API_NAME, path)
     for param in search_params:
-        # Skip page, pageIndex or offset parameters as they will be updated to point to next, previous and last page
+        # Skip page, pageIndex or offset parameters as they will be updated to point to
+        # next, previous and last page
         if param == "page" or param == "pageIndex" or param == "offset":
             continue
         iri += "{}={}&".format(param, search_params[param])
     return iri
 
 
-def parse_search_params(search_params: Dict[str, Any], session: scoped_session) -> Dict[str, Any]:
+def parse_search_params(search_params: Dict[str, Any],
+                        session: scoped_session) -> Dict[str, Any]:
     """Parse search parameters and create a dict with id of parameters as keys.
     :param search_params: Dictionary having input search parameters.
     :param session: sqlalchemy session.
@@ -853,7 +860,8 @@ def pre_process_pagination_parameters(search_params: Dict[str, Any], paginate: b
         if i != incompatible_parameters_len - 1:
             for j in range(i+1, incompatible_parameters_len):
                 if incompatible_parameters[j] in search_params:
-                    raise IncompatibleParameters([incompatible_parameters[i], incompatible_parameters[j]])
+                    raise IncompatibleParameters([incompatible_parameters[i],
+                                                  incompatible_parameters[j]])
     try:
         # Extract page number from query arguments
         if "pageIndex" in search_params:
@@ -873,13 +881,16 @@ def pre_process_pagination_parameters(search_params: Dict[str, Any], paginate: b
             limit = None
     except ValueError:
         raise PageNotFound(page)
-    page_limit, offset = calculate_page_limit_and_offset(paginate=paginate, page_size=page_size, page=page,
-                                                         result_length=result_length, offset=offset, limit=limit)
+    page_limit, offset = calculate_page_limit_and_offset(paginate=paginate, page_size=page_size,
+                                                         page=page, result_length=result_length,
+                                                         offset=offset, limit=limit)
     return page, page_limit, offset
 
 
-def attach_hydra_view(collection_template: Dict[str, Any], paginate_param: str, result_length: int, page_size: int,
-                      iri: str, offset: int = None, page: int = None, last: int = None) -> None:
+def attach_hydra_view(collection_template: Dict[str, Any], paginate_param: str,
+                      result_length: int, page_size: int,
+                      iri: str, offset: int = None,
+                      page: int = None, last: int = None) -> None:
     """Attaches hydra:view to the collection template.
     :param collection_template: the collection template.
     :param paginate_param: type of paginate parameter used.
@@ -888,8 +899,8 @@ def attach_hydra_view(collection_template: Dict[str, Any], paginate_param: str, 
     :param iri: IRI of the collection with query parameters except "page", "pageIndex" and "offset".
     :param offset: offset used for pagination, None if not used.
     :param page: page number used for pagination, None if not used.
-    :param last: Page number of the last page only used when "page" or "pageIndex" is used for pagination
-                    None otherwise.
+    :param last: Page number of the last page only used when "page" or "pageIndex"
+                 is used for pagination, None otherwise.
     """
     if paginate_param == "offset":
         collection_template["view"] = {
@@ -900,10 +911,12 @@ def attach_hydra_view(collection_template: Dict[str, Any], paginate_param: str, 
         }
         if offset > page_size:
             collection_template["view"]["previous"] = "{}{}={}".format(iri,
-                                                                       paginate_param, offset - page_size)
+                                                                       paginate_param,
+                                                                       offset - page_size)
         if offset < result_length-page_size:
             collection_template["view"]["next"] = "{}{}={}".format(iri,
-                                                                   paginate_param, offset + page_size)
+                                                                   paginate_param,
+                                                                   offset + page_size)
     else:
         collection_template["view"] = {
             "@id": "{}{}={}".format(iri, paginate_param, page),
@@ -912,7 +925,8 @@ def attach_hydra_view(collection_template: Dict[str, Any], paginate_param: str, 
             "last": "{}{}={}".format(iri, paginate_param, last)
         }
         if page != 1:
-            collection_template["view"]["previous"] = "{}{}={}".format(iri, paginate_param, page-1)
+            collection_template["view"]["previous"] = "{}{}={}".format(iri, paginate_param,
+                                                                       page-1)
         if page != last:
-            collection_template["view"]["next"] = "{}{}={}".format(iri, paginate_param, page + 1)
-    return collection_template
+            collection_template["view"]["next"] = "{}{}={}".format(iri, paginate_param,
+                                                                   page + 1)

--- a/hydrus/data/exceptions.py
+++ b/hydrus/data/exceptions.py
@@ -120,7 +120,7 @@ class UserNotFound(Exception):
 
 
 class PageNotFound(Exception):
-    """Error when the User is not found."""
+    """Error when the page is not found."""
 
     def __init__(self, page_id: str) -> None:
         """Constructor."""
@@ -161,3 +161,17 @@ class IncompatibleParameters(Exception):
             else:
                 description += "{}, ".format(self.params[i])
         return HydraError(code=400, title="Incompatible parameters.", desc=description)
+
+
+class OffsetOutOfRange(Exception):
+    """Error when the offset provided by client is out of range"""
+
+    def __init__(self, offset: str) -> None:
+        """Constructor."""
+        self.offset = offset
+
+    def get_HTTP(self) -> HydraError:
+        """Return the HTTP response for the Exception."""
+        description = "Offset {} is out of range.".format(self.offset)
+        return HydraError(code=400, title="Page not found", desc=description)
+

--- a/hydrus/data/exceptions.py
+++ b/hydrus/data/exceptions.py
@@ -174,4 +174,3 @@ class OffsetOutOfRange(Exception):
         """Return the HTTP response for the Exception."""
         description = "Offset {} is out of range.".format(self.offset)
         return HydraError(code=400, title="Page not found", desc=description)
-

--- a/hydrus/data/exceptions.py
+++ b/hydrus/data/exceptions.py
@@ -1,5 +1,5 @@
 """Exceptions for the crud operations."""
-from typing import Dict, Tuple, Union, Any
+from typing import Dict, Tuple, Union, Any, List
 from hydra_python_core.doc_writer import HydraError
 
 
@@ -143,3 +143,21 @@ class InvalidSearchParameter(Exception):
         """Return the HTTP response for the Exception."""
         description = "Query parameter [{}] is invalid".format(self.param)
         return HydraError(code=400, title="Invalid query parameter", desc=description)
+
+
+class IncompatibleParameters(Exception):
+    """Error when two or more query parameters are incompatible with each other."""
+
+    def __init__(self, params: List[str]) -> None:
+        """Constructor."""
+        self.params = params
+
+    def get_HTTP(self) -> HydraError:
+        """Return the HTTP response for the Exception."""
+        description = "Following parameters are incompatible with each other: ["
+        for i in range(len(self.params)):
+            if i == len(self.params) - 1:
+                description += "{}]".format(self.params[i])
+            else:
+                description += "{}, ".format(self.params[i])
+        return HydraError(code=400, title="Incompatible parameters.", desc=description)

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -175,7 +175,7 @@ def finalize_response(class_type: str, obj: Dict[str, Any]) -> Dict[str, Any]:
     return obj
 
 
-def add_iri_template(class_type: str, API_NAME: str, path:str) -> Dict[str, Any]:
+def add_iri_template(class_type: str, API_NAME: str, path: str) -> Dict[str, Any]:
     template_mappings = list()
     template = "/{}/{}(".format(API_NAME, path)
     first = True
@@ -187,25 +187,28 @@ def add_iri_template(class_type: str, API_NAME: str, path:str) -> Dict[str, Any]
     return HydraIriTemplate(template=template, iri_mapping=template_mappings).generate()
 
 
-def generate_iri_mappings(class_type: str, template: str, skip_nested: bool =False,
-                     template_mapping: List[IriTemplateMapping]=[], parent_prop_name: str = None) -> Tuple[str,
-                                                                             List[IriTemplateMapping]]:
+def generate_iri_mappings(class_type: str, template: str, skip_nested: bool = False,
+                          template_mapping: List[IriTemplateMapping] = [],
+                          parent_prop_name: str = None) -> Tuple[str, List[IriTemplateMapping]]:
     """Generate iri mappings to add to IriTemplate
     :param class_type: class name objects contained in collection.
     :param template: IriTemplate string.
-    :param skip_nested: To only add properties of the class_type class or its immediate children.
+    :param skip_nested: To only add properties of the class_type class or
+                        its immediate children.
     :param template_mapping: List of template mappings.
-    :param parent_prop_name: Property name according to parent object (only applies for nested properties)
-    :return: Template string, list of template mappings and boolean showing whether to keep adding
-                delimiter or not.
+    :param parent_prop_name: Property name according to parent object
+                             (only applies for nested properties)
+    :return: Template string, list of template mappings and boolean showing whether
+             to keep adding delimiter or not.
     """
     for supportedProp in get_doc(
     ).parsed_classes[class_type]["class"].supportedProperty:
         if "vocab:" in supportedProp.prop and skip_nested is False:
             prop_class = supportedProp.prop.replace("vocab:", "")
-            template, template_mapping = generate_iri_mappings(prop_class, template, skip_nested=True,
-                                                                               parent_prop_name=supportedProp.title,
-                                                                               template_mapping=template_mapping)
+            template, template_mapping = generate_iri_mappings(prop_class, template,
+                                                               skip_nested=True,
+                                                               parent_prop_name=supportedProp.title,
+                                                               template_mapping=template_mapping)
             continue
         if skip_nested is True:
             var = "{}[{}]".format(parent_prop_name, supportedProp.title)
@@ -218,8 +221,9 @@ def generate_iri_mappings(class_type: str, template: str, skip_nested: bool =Fal
     return template, template_mapping
 
 
-def add_pagination_iri_mappings(template: str, template_mapping: List[IriTemplateMapping]) -> Tuple[str,
-                                                        List[IriTemplateMapping]]:
+def add_pagination_iri_mappings(template: str,
+                                template_mapping: List[IriTemplateMapping]
+                                ) -> Tuple[str, List[IriTemplateMapping]]:
     """Add various pagination related to variable to the IRI template and also adds mappings for them.
     :param template: IriTemplate string.
     :param template_mapping: List of template mappings.

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -179,20 +179,21 @@ def add_iri_template(class_type: str, API_NAME: str, path:str) -> Dict[str, Any]
     template_mappings = list()
     template = "/{}/{}(".format(API_NAME, path)
     first = True
-    template, template_mappings, skip_del = generate_iri_mappings(class_type, template,
-                                                                  template_mapping=template_mappings,)
-    template += ")"
+    template, template_mappings = generate_iri_mappings(class_type, template,
+                                                        template_mapping=template_mappings,)
+
+    template, template_mappings = add_pagination_iri_mappings(template=template,
+                                                              template_mapping=template_mappings)
     return HydraIriTemplate(template=template, iri_mapping=template_mappings).generate()
 
 
-def generate_iri_mappings(class_type: str, template: str, skip_nested: bool =False, skip_delimiter: bool = True,
+def generate_iri_mappings(class_type: str, template: str, skip_nested: bool =False,
                      template_mapping: List[IriTemplateMapping]=[], parent_prop_name: str = None) -> Tuple[str,
-                                                                             List[IriTemplateMapping], bool]:
+                                                                             List[IriTemplateMapping]]:
     """Generate iri mappings to add to IriTemplate
     :param class_type: class name objects contained in collection.
     :param template: IriTemplate string.
     :param skip_nested: To only add properties of the class_type class or its immediate children.
-    :param skip_delimiter: Used to place delimiters between various parameters of template.
     :param template_mapping: List of template mappings.
     :param parent_prop_name: Property name according to parent object (only applies for nested properties)
     :return: Template string, list of template mappings and boolean showing whether to keep adding
@@ -202,8 +203,7 @@ def generate_iri_mappings(class_type: str, template: str, skip_nested: bool =Fal
     ).parsed_classes[class_type]["class"].supportedProperty:
         if "vocab:" in supportedProp.prop and skip_nested is False:
             prop_class = supportedProp.prop.replace("vocab:", "")
-            template, template_mapping, skip_delimiter = generate_iri_mappings(prop_class, template, skip_nested=True,
-                                                                               skip_delimiter=skip_delimiter,
+            template, template_mapping = generate_iri_mappings(prop_class, template, skip_nested=True,
                                                                                parent_prop_name=supportedProp.title,
                                                                                template_mapping=template_mapping)
             continue
@@ -214,9 +214,24 @@ def generate_iri_mappings(class_type: str, template: str, skip_nested: bool =Fal
             var = supportedProp.title
             mapping = IriTemplateMapping(variable=var, prop=supportedProp.prop)
         template_mapping.append(mapping)
-        if skip_delimiter is True:
-            template = template + "{}".format(var)
-            skip_delimiter = False
+        template = template + "{}, ".format(var)
+    return template, template_mapping
+
+
+def add_pagination_iri_mappings(template: str, template_mapping: List[IriTemplateMapping]) -> Tuple[str,
+                                                        List[IriTemplateMapping]]:
+    """Add various pagination related to variable to the IRI template and also adds mappings for them.
+    :param template: IriTemplate string.
+    :param template_mapping: List of template mappings.
+    :return: Final IriTemplate string and related list of mappings.
+    """
+    paginate_variables = ["pageIndex", "limit", "offset"]
+    for i in range(len(paginate_variables)):
+        # If final variable then do not add space and comma and add the final parentheses
+        if i == len(paginate_variables) - 1:
+            template += "{})".format(paginate_variables[i])
         else:
-            template = template + ", {}".format(var)
-    return template, template_mapping, skip_delimiter
+            template += "{}, ".format(paginate_variables[i])
+        mapping = IriTemplateMapping(variable=paginate_variables[i], prop=paginate_variables[i])
+        template_mapping.append(mapping)
+    return template, template_mapping

--- a/hydrus/resources.py
+++ b/hydrus/resources.py
@@ -55,7 +55,8 @@ from hydrus.helpers import (
     check_required_props,
     add_iri_template,
     finalize_response)
-from hydrus.utils import (get_session,
+from hydrus.utils import (
+    get_session,
     get_doc,
     get_api_name,
     get_hydrus_server_url,
@@ -257,7 +258,8 @@ class ItemCollection(Resource):
                     # Get paginated response
                     response = crud.get_collection(
                         get_api_name(), collection.class_.title, session=get_session(),
-                        paginate=True, path=path, page_size=get_page_size(), search_params=search_params)
+                        paginate=True, path=path, page_size=get_page_size(),
+                        search_params=search_params)
                 else:
                     # Get whole collection
                     response = crud.get_collection(
@@ -323,14 +325,16 @@ class ItemCollection(Resource):
                         headers_ = [
                             {"Location": "{}{}/{}/{}".format(
                                 get_hydrus_server_url(), get_api_name(), path, object_id)}]
-                        status_description = "Object with ID {} successfully added".format(object_id)
+                        status_description = "Object with ID {} successfully added".format(
+                            object_id)
                         status = HydraStatus(code=201, title="Object successfully added",
                                              desc=status_description)
                         return set_response_headers(
                             jsonify(status.generate()), headers=headers_, status_code=status.code)
                     except (ClassNotFound, InstanceExists, PropertyNotFound) as e:
                         error = e.get_HTTP()
-                        return set_response_headers(jsonify(error.generate()), status_code=error.code)
+                        return set_response_headers(jsonify(error.generate()),
+                                                    status_code=error.code)
 
                 else:
                     error = HydraError(code=400, title="Data is not valid")
@@ -351,7 +355,8 @@ class ItemCollection(Resource):
                             jsonify(status.generate()), headers=headers_, status_code=status.code)
                     except (ClassNotFound, InstanceExists, PropertyNotFound) as e:
                         error = e.get_HTTP()
-                        return set_response_headers(jsonify(error.generate()), status_code=error.code)
+                        return set_response_headers(jsonify(error.generate()),
+                                                    status_code=error.code)
 
                 else:
                     error = HydraError(code=400, title="Data is not valid")
@@ -475,20 +480,24 @@ class Items(Resource):
                             headers_ = [{"Location": "{}{}/{}/{}".format(
                                     get_hydrus_server_url(), get_api_name(), path, object_id)}]
                             if len(incomplete_objects) > 0:
-                                status = HydraStatus(code=202, title="Object(s) missing required property")
+                                status = HydraStatus(code=202,
+                                                     title="Object(s) missing required property")
                                 response = status.generate()
                                 response["objects"] = incomplete_objects
                                 return set_response_headers(
                                     jsonify(response), headers=headers_, status_code=status.code)
                             else:
-                                status_description = "Objects with ID {} successfully added".format(object_id)
+                                status_description = "Objects with ID {} successfully added".format(
+                                    object_id)
                                 status = HydraStatus(code=201, title="Objects successfully added",
                                                      desc=status_description)
                                 return set_response_headers(
-                                    jsonify(status.generate()), headers=headers_, status_code=status.code)
+                                    jsonify(status.generate()), headers=headers_,
+                                    status_code=status.code)
                         except (ClassNotFound, InstanceExists, PropertyNotFound) as e:
                             error = e.get_HTTP()
-                            return set_response_headers(jsonify(error.generate()), status_code=error.code)
+                            return set_response_headers(jsonify(error.generate()),
+                                                        status_code=error.code)
 
                 error = HydraError(code=400, title="Data is not valid")
                 return set_response_headers(jsonify(error.generate()), status_code=error.code)
@@ -512,8 +521,10 @@ class Items(Resource):
             try:
                 # Delete the Item with ID == id_
                 crud.delete_multiple(int_list, class_type, session=get_session())
-                status_description = "Objects with ID {} successfully deleted".format(int_list.split(','))
-                status = HydraStatus(code=200, title="Objects successfully deleted", desc=status_description)
+                status_description = "Objects with ID {} successfully deleted".format(
+                    int_list.split(','))
+                status = HydraStatus(code=200, title="Objects successfully deleted",
+                                     desc=status_description)
                 return set_response_headers(jsonify(status.generate()))
 
             except (ClassNotFound, InstanceNotFound) as e:

--- a/hydrus/resources.py
+++ b/hydrus/resources.py
@@ -40,7 +40,8 @@ from hydrus.data.exceptions import (
     PropertyNotFound,
     InstanceNotFound,
     PageNotFound,
-    InvalidSearchParameter)
+    InvalidSearchParameter,
+    OffsetOutOfRange)
 from hydrus.helpers import (
     set_response_headers,
     checkClassOp,
@@ -268,7 +269,7 @@ class ItemCollection(Resource):
 
                 return set_response_headers(jsonify(hydrafy(response, path=path)))
 
-            except (ClassNotFound, PageNotFound, InvalidSearchParameter) as e:
+            except (ClassNotFound, PageNotFound, InvalidSearchParameter, OffsetOutOfRange) as e:
                 error = e.get_HTTP()
                 return set_response_headers(jsonify(error.generate()), status_code=error.code)
 

--- a/hydrus/tests/test_app.py
+++ b/hydrus/tests/test_app.py
@@ -426,7 +426,8 @@ class ViewsTestCase(unittest.TestCase):
                 class_ = self.doc.parsed_classes[collection.class_.title]["class"]
                 class_props = [x.prop for x in class_.supportedProperty]
                 for mapping in response_get_data["search"]["mapping"]:
-                    assert mapping["property"] in class_props
+                    if mapping["property"] not in ["limit", "offset", "pageIndex"]:
+                        assert mapping["property"] in class_props
 
     def test_GET_for_nested_class(self):
         index = self.client.get("/{}".format(self.API_NAME))

--- a/hydrus/tests/test_app.py
+++ b/hydrus/tests/test_app.py
@@ -93,7 +93,8 @@ class ViewsTestCase(unittest.TestCase):
                 id_=str(
                     uuid.uuid4()),
                 session=self.session)
-            # If it's a collection class then add an extra object so we can test pagination thoroughly.
+            # If it's a collection class then add an extra object so
+            # we can test pagination thoroughly.
             if class_ in self.doc.collections:
                 crud.insert(
                     dummy_obj,
@@ -182,7 +183,8 @@ class ViewsTestCase(unittest.TestCase):
                             class_methods = [
                                 x.method for x in class_.supportedOperation]
                             if "GET" in class_methods:
-                                item_response = self.client.get(response_get_data["members"][0]["@id"])
+                                item_response = self.client.get(
+                                    response_get_data["members"][0]["@id"])
                                 assert item_response.status_code == 200
 
     def test_pagination(self):
@@ -430,7 +432,8 @@ class ViewsTestCase(unittest.TestCase):
                         assert mapping["property"] in class_props
 
     def test_client_controlled_pagination(self):
-        """Test pagination controlled by client with help of pageIndex, offset and limit parameters."""
+        """Test pagination controlled by client with help of pageIndex,
+        offset and limit parameters."""
         index = self.client.get("/{}".format(self.API_NAME))
         assert index.status_code == 200
         endpoints = json.loads(index.data.decode('utf-8'))
@@ -446,7 +449,7 @@ class ViewsTestCase(unittest.TestCase):
                 assert "mapping" in response_get_data["search"]
                 # Test with pageIndex and limit
                 params = {"pageIndex": 1, "limit": 2}
-                response_for_page_param = self.client.get(endpoints[endpoint], query_string= params)
+                response_for_page_param = self.client.get(endpoints[endpoint], query_string=params)
                 assert response_for_page_param.status_code == 200
                 response_for_page_param_data = json.loads(
                     response_for_page_param.data.decode('utf-8'))
@@ -462,7 +465,8 @@ class ViewsTestCase(unittest.TestCase):
                     assert "pageIndex=1" in next_response_data["view"]["previous"]
                     # Test with offset and limit
                     params = {"offset": 1, "limit": 2}
-                    response_for_offset_param = self.client.get(endpoints[endpoint], query_string=params)
+                    response_for_offset_param = self.client.get(endpoints[endpoint],
+                                                                query_string=params)
                     assert response_for_offset_param.status_code == 200
                     response_for_offset_param_data = json.loads(
                         response_for_offset_param.data.decode('utf-8'))
@@ -470,7 +474,8 @@ class ViewsTestCase(unittest.TestCase):
                     assert "last" in response_for_offset_param_data["view"]
                     if "next" in response_for_offset_param_data["view"]:
                         assert "offset=3" in response_for_offset_param_data["view"]["next"]
-                        next_response = self.client.get(response_for_offset_param_data["view"]["next"])
+                        next_response = self.client.get(
+                            response_for_offset_param_data["view"]["next"])
                         assert next_response.status_code == 200
                         next_response_data = json.loads(
                             next_response.data.decode('utf-8'))

--- a/hydrus/tests/test_app.py
+++ b/hydrus/tests/test_app.py
@@ -429,6 +429,54 @@ class ViewsTestCase(unittest.TestCase):
                     if mapping["property"] not in ["limit", "offset", "pageIndex"]:
                         assert mapping["property"] in class_props
 
+    def test_client_controlled_pagination(self):
+        """Test pagination controlled by client with help of pageIndex, offset and limit parameters."""
+        index = self.client.get("/{}".format(self.API_NAME))
+        assert index.status_code == 200
+        endpoints = json.loads(index.data.decode('utf-8'))
+        for endpoint in endpoints:
+            collection_name = "/".join(endpoints[endpoint].split(
+                "/{}/".format(self.API_NAME))[1:])
+            if collection_name in self.doc.collections:
+                response_get = self.client.get(endpoints[endpoint])
+                assert response_get.status_code == 200
+                response_get_data = json.loads(
+                    response_get.data.decode('utf-8'))
+                assert "search" in response_get_data
+                assert "mapping" in response_get_data["search"]
+                # Test with pageIndex and limit
+                params = {"pageIndex": 1, "limit": 2}
+                response_for_page_param = self.client.get(endpoints[endpoint], query_string= params)
+                assert response_for_page_param.status_code == 200
+                response_for_page_param_data = json.loads(
+                    response_for_page_param.data.decode('utf-8'))
+                assert "first" in response_for_page_param_data["view"]
+                assert "last" in response_for_page_param_data["view"]
+                if "next" in response_for_page_param_data["view"]:
+                    assert "pageIndex=2" in response_for_page_param_data["view"]["next"]
+                    next_response = self.client.get(response_for_page_param_data["view"]["next"])
+                    assert next_response.status_code == 200
+                    next_response_data = json.loads(
+                        next_response.data.decode('utf-8'))
+                    assert "previous" in next_response_data["view"]
+                    assert "pageIndex=1" in next_response_data["view"]["previous"]
+                    # Test with offset and limit
+                    params = {"offset": 1, "limit": 2}
+                    response_for_offset_param = self.client.get(endpoints[endpoint], query_string=params)
+                    assert response_for_offset_param.status_code == 200
+                    response_for_offset_param_data = json.loads(
+                        response_for_offset_param.data.decode('utf-8'))
+                    assert "first" in response_for_offset_param_data["view"]
+                    assert "last" in response_for_offset_param_data["view"]
+                    if "next" in response_for_offset_param_data["view"]:
+                        assert "offset=3" in response_for_offset_param_data["view"]["next"]
+                        next_response = self.client.get(response_for_offset_param_data["view"]["next"])
+                        assert next_response.status_code == 200
+                        next_response_data = json.loads(
+                            next_response.data.decode('utf-8'))
+                        assert "previous" in next_response_data["view"]
+                        assert "offset=1" in next_response_data["view"]["previous"]
+
     def test_GET_for_nested_class(self):
         index = self.client.get("/{}".format(self.API_NAME))
         assert index.status_code == 200

--- a/hydrus/tests/test_crud.py
+++ b/hydrus/tests/test_crud.py
@@ -106,7 +106,8 @@ class TestCRUD(unittest.TestCase):
             target_property_1 = ""
             target_property_2 = ""
             for prop in self.doc.parsed_classes[class_]["class"].supportedProperty:
-                # Find nested object so we can test searching of elements by properties of nested objects.
+                # Find nested object so we can test searching of elements by
+                # properties of nested objects.
                 if "vocab:" in prop.prop:
                     object_ = gen_dummy_object(class_, self.doc)
                     # Setting property of a nested object as target
@@ -133,8 +134,9 @@ class TestCRUD(unittest.TestCase):
 
                     obj_id = str(uuid.uuid4())
                     response = crud.insert(object_=object_, id_=obj_id, session=self.session)
-                    search_result = crud.get_collection(API_NAME="api", type_=class_, session=self.session,
-                                                        paginate=True, page_size=5, search_params=search_params)
+                    search_result = crud.get_collection(API_NAME="api", type_=class_,
+                                                        session=self.session, paginate=True,
+                                                        page_size=5, search_params=search_params)
                     assert len(search_result["members"]) > 0
                     search_item_id = search_result["members"][0]["@id"].split('/')[-1]
                     assert search_item_id == obj_id

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,23 +98,19 @@ class CliTests(unittest.TestCase):
 
     def test_startserver(self):
         runner = CliRunner()
+        # Starting server with valid parameters
+        result = runner.invoke(startserver,
+                               ["--adduser", "--api", "--no-auth", "--dburl",
+                                "--hydradoc", "--port", "--no-token", "--serverurl",
+                                "serve"])
+        result.exit_code != 0
 
-        #starting ther server
+        # Starting server with invalid parameters
 
         result = runner.invoke(startserver,
-        ["--adduser","--api","--no-auth","--dburl",
-        "--hydradoc","--port","--no-token","--serverurl",
-        "serve"])  
-        result.exit_code !=0
-
-        #starting server with invalid params
-
-        result = runner.invoke(startserver,
-        ["--adduser","sqlite://not-valid","http://localhost",
-        "--port","serve"])
+                               ["--adduser", "sqlite://not-valid", "http://localhost",
+                                "--port", "serve"])
         assert result.exit_code == 2
-
-    
 
 
 if __name__ == '__main__':

--- a/tests/test_pep8.py
+++ b/tests/test_pep8.py
@@ -19,7 +19,7 @@ class Pep8Test(unittest.TestCase):
         # Set this to desired folder location
         for root, _, files in os.walk(self.file_structure):
             python_files = [f for f in files if f.endswith(
-                '.py') and f.find("examples") == 0]
+                '.py') and "examples" not in root]
             for file in python_files:
                 if len(root.split('samples')) != 2:     # Ignore samples directory
                     filename = '{0}/{1}'.format(root, file)


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #302 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Refactors some old code and provides clients way to control pagination parameters `pageIndex`, `limit` and `offset`.


### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
