### PR TITLE
Use HydraLink to improve handling of nested class properties

### DIFF
--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -31,7 +31,7 @@
     typing : Module which provides support for type hints .
 
 """  # nopep8
-from sqlalchemy.orm import sessionmaker, scoped_session
+import re
 from sqlalchemy.orm import with_polymorphic
 from sqlalchemy import exists
 from sqlalchemy.orm.exc import NoResultFound
@@ -186,7 +186,18 @@ def insert(object_: Dict[str, Any], session: scoped_session,
                 # Adds new Property
                 session.close()
                 raise PropertyNotFound(type_=prop_name)
-
+            # For insertion in III through link
+            if isinstance(object_[prop_name], str):
+                regex = r'/.*/.*/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}'
+                matchObj = re.match(regex, object_[prop_name])
+                if matchObj:
+                    nested_obj_id = object_[prop_name].split('/')[-1]
+                    triple = GraphIII(
+                        subject=instance.id,
+                        predicate=property_.id,
+                        object_=nested_obj_id)
+                    session.add(triple)
+                    continue
             # For insertion in III
             if isinstance(object_[prop_name], dict):
                 try:

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -307,3 +307,19 @@ def get_link_props(class_type: str, object_) -> Union[Dict[str, Any], bool]:
                         link_props[supportedProp.title] = class_title
                         break
     return link_props
+
+
+def get_link_props_for_multiple_objects(class_type: str,
+                                        object_list: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Get link_props of multiple objects.
+    :param class_type: Class type of objects.
+    :param object_list: List of objects being inserted.
+    :return: List of link properties processed with the help of get_link_props.
+    """
+    link_prop_list = list()
+    for object_ in object_list:
+        if get_link_props(class_type, object_) is False:
+            return False
+        link_prop_list.append(get_link_props(class_type, object_))
+    return link_prop_list

--- a/hydrus/resources.py
+++ b/hydrus/resources.py
@@ -56,7 +56,8 @@ from hydrus.helpers import (
     add_iri_template,
     finalize_response,
     send_sync_update,
-    get_link_props)
+    get_link_props,
+    get_link_props_for_multiple_objects)
 from hydrus.utils import (
     get_session,
     get_doc,
@@ -512,7 +513,8 @@ class Items(Resource):
                     if not check_required_props(obj_type, obj):
                         incomplete_objects.append(obj)
                         object_.remove(obj)
-                if validObjectList(object_):
+                link_props_list = get_link_props_for_multiple_objects(obj_type, object_)
+                if validObjectList(object_) and isinstance(link_props_list, list):
                     type_result = type_match(object_, obj_type)
                     # If Item in request's JSON is a valid object
                     # ie. @type is one of the keys in object_
@@ -522,7 +524,8 @@ class Items(Resource):
                         try:
                             # Insert object and return location in Header
                             object_id = crud.insert_multiple(
-                                objects_=object_, session=get_session(), id_=int_list)
+                                objects_=object_, session=get_session(), id_=int_list,
+                                link_props_list=link_props_list)
                             headers_ = [{"Location": "{}{}/{}/{}".format(
                                     get_hydrus_server_url(), get_api_name(), path, object_id)}]
                             if len(incomplete_objects) > 0:

--- a/hydrus/resources.py
+++ b/hydrus/resources.py
@@ -55,7 +55,8 @@ from hydrus.helpers import (
     check_required_props,
     add_iri_template,
     finalize_response,
-    send_sync_update)
+    send_sync_update,
+    get_link_props)
 from hydrus.utils import (
     get_session,
     get_doc,
@@ -144,15 +145,17 @@ class Item(Resource):
         if checkClassOp(class_type, "POST") and check_writeable_props(class_type, object_):
             # Check if class_type supports POST operation
             obj_type = getType(class_type, "POST")
+            link_props = get_link_props(class_type, object_)
             # Load new object and type
             if validObject(object_) and object_["@type"] == obj_type and check_required_props(
-                    class_type, object_):
+                    class_type, object_) and isinstance(link_props, Dict):
                 try:
                     # Update the right ID if the object is valid and matches
                     # type of Item
                     object_id = crud.update(
                         object_=object_,
                         id_=id_,
+                        link_props=link_props,
                         type_=object_["@type"],
                         session=get_session(),
                         api_name=get_api_name())
@@ -195,12 +198,14 @@ class Item(Resource):
             # Check if class_type supports PUT operation
             object_ = json.loads(request.data.decode('utf-8'))
             obj_type = getType(class_type, "PUT")
+            link_props = get_link_props(class_type, object_)
             # Load new object and type
             if validObject(object_) and object_["@type"] == obj_type and check_required_props(
-                    class_type, object_):
+                    class_type, object_) and isinstance(link_props, Dict):
                 try:
                     # Add the object with given ID
-                    object_id = crud.insert(object_=object_, id_=id_, session=get_session())
+                    object_id = crud.insert(object_=object_, id_=id_,
+                                            link_props=link_props, session=get_session())
                     headers_ = [{"Location": "{}{}/{}/{}".format(
                         get_hydrus_server_url(), get_api_name(), path, object_id)}]
                     status_description = "Object with ID {} successfully added".format(object_id)
@@ -363,10 +368,12 @@ class ItemCollection(Resource):
             ).collections:
                 # If path is in parsed_classes but is not a collection
                 obj_type = getType(path, "PUT")
+                link_props = get_link_props(obj_type, object_)
                 if object_["@type"] == obj_type and validObject(object_) and check_required_props(
-                        obj_type, object_):
+                        obj_type, object_) and isinstance(link_props, Dict):
                     try:
-                        object_id = crud.insert(object_=object_, session=get_session())
+                        object_id = crud.insert(object_=object_, link_props=link_props,
+                                                session=get_session())
                         headers_ = [{"Location": "{}{}/{}/".format(
                                 get_hydrus_server_url(), get_api_name(), path)}]
                         status = HydraStatus(code=201, title="Object successfully added")
@@ -400,14 +407,17 @@ class ItemCollection(Resource):
             if path in get_doc().parsed_classes and "{}Collection".format(path) not in get_doc(
             ).collections:
                 obj_type = getType(path, "POST")
+                link_props = get_link_props(obj_type, object_)
                 if check_writeable_props(obj_type, object_):
                     if object_["@type"] == obj_type and check_required_props(
-                            obj_type, object_) and validObject(object_):
+                            obj_type, object_) and validObject(object_) and isinstance(
+                                    link_props, Dict):
                         try:
                             crud.update_single(
                                 object_=object_,
                                 session=get_session(),
                                 api_name=get_api_name(),
+                                link_props=link_props,
                                 path=path)
                             method = "POST"
                             resource_url = "{}{}/{}".format(

--- a/hydrus/resources.py
+++ b/hydrus/resources.py
@@ -146,10 +146,10 @@ class Item(Resource):
         if checkClassOp(class_type, "POST") and check_writeable_props(class_type, object_):
             # Check if class_type supports POST operation
             obj_type = getType(class_type, "POST")
-            link_props = get_link_props(class_type, object_)
+            link_props, link_type_check = get_link_props(class_type, object_)
             # Load new object and type
             if validObject(object_) and object_["@type"] == obj_type and check_required_props(
-                    class_type, object_) and isinstance(link_props, Dict):
+                    class_type, object_) and link_type_check:
                 try:
                     # Update the right ID if the object is valid and matches
                     # type of Item
@@ -199,10 +199,10 @@ class Item(Resource):
             # Check if class_type supports PUT operation
             object_ = json.loads(request.data.decode('utf-8'))
             obj_type = getType(class_type, "PUT")
-            link_props = get_link_props(class_type, object_)
+            link_props, link_type_check = get_link_props(class_type, object_)
             # Load new object and type
             if validObject(object_) and object_["@type"] == obj_type and check_required_props(
-                    class_type, object_) and isinstance(link_props, Dict):
+                    class_type, object_) and link_type_check:
                 try:
                     # Add the object with given ID
                     object_id = crud.insert(object_=object_, id_=id_,
@@ -369,9 +369,9 @@ class ItemCollection(Resource):
             ).collections:
                 # If path is in parsed_classes but is not a collection
                 obj_type = getType(path, "PUT")
-                link_props = get_link_props(obj_type, object_)
+                link_props, link_type_check = get_link_props(obj_type, object_)
                 if object_["@type"] == obj_type and validObject(object_) and check_required_props(
-                        obj_type, object_) and isinstance(link_props, Dict):
+                        obj_type, object_) and link_type_check:
                     try:
                         object_id = crud.insert(object_=object_, link_props=link_props,
                                                 session=get_session())
@@ -408,11 +408,10 @@ class ItemCollection(Resource):
             if path in get_doc().parsed_classes and "{}Collection".format(path) not in get_doc(
             ).collections:
                 obj_type = getType(path, "POST")
-                link_props = get_link_props(obj_type, object_)
+                link_props, link_type_check = get_link_props(obj_type, object_)
                 if check_writeable_props(obj_type, object_):
                     if object_["@type"] == obj_type and check_required_props(
-                            obj_type, object_) and validObject(object_) and isinstance(
-                                    link_props, Dict):
+                            obj_type, object_) and validObject(object_) and link_type_check:
                         try:
                             crud.update_single(
                                 object_=object_,
@@ -513,8 +512,9 @@ class Items(Resource):
                     if not check_required_props(obj_type, obj):
                         incomplete_objects.append(obj)
                         object_.remove(obj)
-                link_props_list = get_link_props_for_multiple_objects(obj_type, object_)
-                if validObjectList(object_) and isinstance(link_props_list, list):
+                link_props_list, link_type_check = get_link_props_for_multiple_objects(obj_type,
+                                                                                       object_)
+                if validObjectList(object_) and link_type_check:
                     type_result = type_match(object_, obj_type)
                     # If Item in request's JSON is a valid object
                     # ie. @type is one of the keys in object_

--- a/hydrus/samples/doc_writer_sample.py
+++ b/hydrus/samples/doc_writer_sample.py
@@ -125,7 +125,7 @@ range_="vocab:dummyClass")
 class_2.add_supported_prop(HydraClassProp(
     dummy_prop_link, "dummyProp", required=False, read=True, write=True))
 class_2.add_supported_prop(HydraClassProp(
-    "vocab:anotherSingleClass", "singleClassProp", required=False, read=False, write=False))
+    "vocab:anotherSingleClass", "singleClassProp", required=False, read=True, write=True))
 class_1.add_supported_prop(dummyProp1)
 # Add the operations to the classes
 class_.add_supported_op(op1)

--- a/hydrus/samples/doc_writer_sample.py
+++ b/hydrus/samples/doc_writer_sample.py
@@ -1,7 +1,7 @@
 """Sample to create Hydra APIDocumentation using doc_writer."""
 
 from hydra_python_core.doc_writer import (HydraDoc, HydraClass, HydraClassProp, HydraClassOp,
-                                          HydraStatus, HydraError)
+                                          HydraStatus, HydraError, HydraLink)
 from typing import Any, Dict, Union
 
 # Creating the HydraDoc object, this is the primary class for the Doc
@@ -120,8 +120,10 @@ class_.add_supported_prop(dummyProp1)
 class_.add_supported_prop(dummyProp2)
 class_2.add_supported_prop(dummyProp1)
 class_2.add_supported_prop(dummyProp2)
+dummy_prop_link = HydraLink("singleClass/dummyProp", "dummyProp", domain="vocab:singleClass",
+range_="vocab:dummyClass")
 class_2.add_supported_prop(HydraClassProp(
-    "vocab:dummyClass", "dummyProp", required=False, read=True, write=True))
+    dummy_prop_link, "dummyProp", required=False, read=True, write=True))
 class_2.add_supported_prop(HydraClassProp(
     "vocab:anotherSingleClass", "singleClassProp", required=False, read=False, write=False))
 class_1.add_supported_prop(dummyProp1)

--- a/hydrus/samples/doc_writer_sample_output.py
+++ b/hydrus/samples/doc_writer_sample_output.py
@@ -53,128 +53,6 @@ doc = {
     "possibleStatus": [],
     "supportedClass": [
         {
-            "@id": "vocab:extraClass",
-            "@type": "hydra:Class",
-            "description": "Class without any explicit methods",
-            "supportedOperation": [],
-            "supportedProperty": [],
-            "title": "extraClass"
-        },
-        {
-            "@id": "vocab:singleClass",
-            "@type": "hydra:Class",
-            "description": "A non collection class",
-            "supportedOperation": [
-                {
-                    "@type": "http://schema.org/UpdateAction",
-                    "expects": "vocab:singleClass",
-                    "expectsHeader": [],
-                    "method": "POST",
-                    "possibleStatus": [
-                        {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                            "@type": "Status",
-                            "description": "",
-                            "statusCode": 200,
-                            "title": "singleClass changed."
-                        }
-                    ],
-                    "returns": "null",
-                    "returnsHeader": [],
-                    "title": "UpdateClass"
-                },
-                {
-                    "@type": "http://schema.org/DeleteAction",
-                    "expects": "null",
-                    "expectsHeader": [],
-                    "method": "DELETE",
-                    "possibleStatus": [
-                        {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                            "@type": "Status",
-                            "description": "",
-                            "statusCode": 200,
-                            "title": "singleClass deleted."
-                        }
-                    ],
-                    "returns": "null",
-                    "returnsHeader": [],
-                    "title": "DeleteClass"
-                },
-                {
-                    "@type": "http://schema.org/AddAction",
-                    "expects": "vocab:singleClass",
-                    "expectsHeader": [],
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                            "@type": "Status",
-                            "description": "",
-                            "statusCode": 201,
-                            "title": "singleClass successfully added."
-                        }
-                    ],
-                    "returns": "null",
-                    "returnsHeader": [],
-                    "title": "AddClass"
-                },
-                {
-                    "@type": "http://schema.org/FindAction",
-                    "expects": "null",
-                    "expectsHeader": [],
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                            "@type": "Status",
-                            "description": "",
-                            "statusCode": 200,
-                            "title": "singleClass returned."
-                        }
-                    ],
-                    "returns": "vocab:singleClass",
-                    "returnsHeader": [],
-                    "title": "GetClass"
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://props.hydrus.com/prop1",
-                    "readable": "false",
-                    "required": "true",
-                    "title": "Prop1",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://props.hydrus.com/prop1",
-                    "readable": "true",
-                    "required": "false",
-                    "title": "Prop2",
-                    "writeable": "false"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "vocab:dummyClass",
-                    "readable": "true",
-                    "required": "false",
-                    "title": "dummyProp",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "vocab:anotherSingleClass",
-                    "readable": "false",
-                    "required": "false",
-                    "title": "singleClassProp",
-                    "writeable": "false"
-                }
-            ],
-            "title": "singleClass"
-        },
-        {
             "@id": "vocab:dummyClass",
             "@type": "hydra:Class",
             "description": "A dummyClass for demo",
@@ -276,6 +154,14 @@ doc = {
             "title": "dummyClass"
         },
         {
+            "@id": "vocab:extraClass",
+            "@type": "hydra:Class",
+            "description": "Class without any explicit methods",
+            "supportedOperation": [],
+            "supportedProperty": [],
+            "title": "extraClass"
+        },
+        {
             "@id": "vocab:anotherSingleClass",
             "@type": "hydra:Class",
             "description": "An another non collection class",
@@ -310,6 +196,128 @@ doc = {
                 }
             ],
             "title": "anotherSingleClass"
+        },
+        {
+            "@id": "vocab:singleClass",
+            "@type": "hydra:Class",
+            "description": "A non collection class",
+            "supportedOperation": [
+                {
+                    "@type": "http://schema.org/UpdateAction",
+                    "expects": "vocab:singleClass",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "",
+                            "statusCode": 200,
+                            "title": "singleClass changed."
+                        }
+                    ],
+                    "returns": "null",
+                    "returnsHeader": [],
+                    "title": "UpdateClass"
+                },
+                {
+                    "@type": "http://schema.org/DeleteAction",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "",
+                            "statusCode": 200,
+                            "title": "singleClass deleted."
+                        }
+                    ],
+                    "returns": "null",
+                    "returnsHeader": [],
+                    "title": "DeleteClass"
+                },
+                {
+                    "@type": "http://schema.org/AddAction",
+                    "expects": "vocab:singleClass",
+                    "expectsHeader": [],
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "",
+                            "statusCode": 201,
+                            "title": "singleClass successfully added."
+                        }
+                    ],
+                    "returns": "null",
+                    "returnsHeader": [],
+                    "title": "AddClass"
+                },
+                {
+                    "@type": "http://schema.org/FindAction",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "",
+                            "statusCode": 200,
+                            "title": "singleClass returned."
+                        }
+                    ],
+                    "returns": "vocab:singleClass",
+                    "returnsHeader": [],
+                    "title": "GetClass"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://props.hydrus.com/prop1",
+                    "readable": "false",
+                    "required": "true",
+                    "title": "Prop1",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://props.hydrus.com/prop1",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Prop2",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": {
+                        "@id": "vocab:singleClass/dummyProp",
+                        "@type": "hydra:Link",
+                        "description": "",
+                        "domain": "vocab:singleClass",
+                        "range": "vocab:dummyClass",
+                        "supportedOperation": [],
+                        "title": "dummyProp"
+                    },
+                    "readable": "true",
+                    "required": "false",
+                    "title": "dummyProp",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "vocab:anotherSingleClass",
+                    "readable": "false",
+                    "required": "false",
+                    "title": "singleClassProp",
+                    "writeable": "false"
+                }
+            ],
+            "title": "singleClass"
         },
         {
             "@id": "http://www.w3.org/ns/hydra/core#Resource",
@@ -455,6 +463,43 @@ doc = {
             ],
             "supportedProperty": [
                 {
+                    "hydra:description": "The anotherSingleClass Class",
+                    "hydra:title": "anothersingleclass",
+                    "property": {
+                        "@id": "vocab:EntryPoint/anotherSingleClass",
+                        "@type": "hydra:Link",
+                        "description": "An another non collection class",
+                        "domain": "vocab:EntryPoint",
+                        "label": "anotherSingleClass",
+                        "range": "vocab:anotherSingleClass",
+                        "supportedOperation": [
+                            {
+                                "@id": "getclass",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "null",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "label": "GetClass",
+                                "method": "GET",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "",
+                                        "statusCode": 200,
+                                        "title": "anotherSingleClass returned."
+                                    }
+                                ],
+                                "returns": "vocab:anotherSingleClass",
+                                "returnsHeader": []
+                            }
+                        ]
+                    },
+                    "readable": "true",
+                    "required": "null",
+                    "writeable": "false"
+                },
+                {
                     "hydra:description": "The singleClass Class",
                     "hydra:title": "singleclass",
                     "property": {
@@ -543,43 +588,6 @@ doc = {
                                     }
                                 ],
                                 "returns": "vocab:singleClass",
-                                "returnsHeader": []
-                            }
-                        ]
-                    },
-                    "readable": "true",
-                    "required": "null",
-                    "writeable": "false"
-                },
-                {
-                    "hydra:description": "The anotherSingleClass Class",
-                    "hydra:title": "anothersingleclass",
-                    "property": {
-                        "@id": "vocab:EntryPoint/anotherSingleClass",
-                        "@type": "hydra:Link",
-                        "description": "An another non collection class",
-                        "domain": "vocab:EntryPoint",
-                        "label": "anotherSingleClass",
-                        "range": "vocab:anotherSingleClass",
-                        "supportedOperation": [
-                            {
-                                "@id": "getclass",
-                                "@type": "http://schema.org/FindAction",
-                                "description": "null",
-                                "expects": "null",
-                                "expectsHeader": [],
-                                "label": "GetClass",
-                                "method": "GET",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                                        "@type": "Status",
-                                        "description": "",
-                                        "statusCode": 200,
-                                        "title": "anotherSingleClass returned."
-                                    }
-                                ],
-                                "returns": "vocab:anotherSingleClass",
                                 "returnsHeader": []
                             }
                         ]

--- a/hydrus/samples/hydra_doc_sample.py
+++ b/hydrus/samples/hydra_doc_sample.py
@@ -499,9 +499,17 @@ doc = {
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "property": "vocab:State",
+                    "property": {
+                        "@id": "vocab:Drone/DroneState",
+                        "@type": "hydra:Link",
+                        "description": "",
+                        "domain": "vocab:Drone",
+                        "range": "vocab:State",
+                        "supportedOperation": [],
+                        "title": "Drone State"
+                    },
                     "readable": "true",
-                    "required": "true",
+                    "required": "false",
                     "title": "DroneState",
                     "writeable": "true"
                 },

--- a/hydrus/tests/test_crud.py
+++ b/hydrus/tests/test_crud.py
@@ -10,6 +10,7 @@ from hydrus.data.db_models import Base
 from hydrus.data import doc_parse
 from hydra_python_core import doc_maker
 from hydrus.samples.hydra_doc_sample import doc
+from hydra_python_core.doc_writer import HydraLink
 
 import random
 from typing import List
@@ -23,6 +24,8 @@ def gen_dummy_object(class_, doc):
     }
     if class_ in doc.parsed_classes:
         for prop in doc.parsed_classes[class_]["class"].supportedProperty:
+            if isinstance(prop.prop, HydraLink):
+                continue
             if "vocab:" in prop.prop:
                 prop_class = prop.prop.replace("vocab:", "")
                 object_[prop.title] = gen_dummy_object(prop_class, doc)
@@ -86,6 +89,8 @@ class TestCRUD(unittest.TestCase):
         """Test get operation for object that can contain other objects."""
         for class_ in self.doc_collection_classes:
             for prop in self.doc.parsed_classes[class_]["class"].supportedProperty:
+                if isinstance(prop.prop, HydraLink):
+                    continue
                 if "vocab:" in prop.prop:
                     nested_class = prop.prop.replace("vocab:", "")
                     object_ = gen_dummy_object(class_, self.doc)
@@ -106,6 +111,8 @@ class TestCRUD(unittest.TestCase):
             target_property_1 = ""
             target_property_2 = ""
             for prop in self.doc.parsed_classes[class_]["class"].supportedProperty:
+                if isinstance(prop.prop, HydraLink):
+                    continue
                 # Find nested object so we can test searching of elements by
                 # properties of nested objects.
                 if "vocab:" in prop.prop:

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ six==1.11.0
 SQLAlchemy
 thespian==3.9.2
 Werkzeug
-git+https://github.com/vddesai1871/hydra-python-core@hydra_link#egg=hydra_python_core
+git+https://github.com/HTTP-APIs/hydra-python-core@master#egg=hydra_python_core
 git+https://github.com/HTTP-APIs/hydra-openapi-parser@0.1.1#egg=hydra_openapi_parser

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ six==1.11.0
 SQLAlchemy
 thespian==3.9.2
 Werkzeug
-git+https://github.com/HTTP-APIs/hydra-python-core@develop#egg=hydra_python_core
+git+https://github.com/vddesai1871/hydra-python-core@hydra_link#egg=hydra_python_core
 git+https://github.com/HTTP-APIs/hydra-openapi-parser@0.1.1#egg=hydra_openapi_parser

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from hydrus.app_factory import app_factory
 from hydrus.utils import set_session, set_doc, set_api_name
 from hydrus.data import doc_parse, crud
 from hydra_python_core import doc_maker
+from hydra_python_core.doc_writer import HydraLink
 from hydrus.samples import doc_writer_sample
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
@@ -25,6 +26,8 @@ def gen_dummy_object(class_, doc):
     }
     if class_ in doc.parsed_classes:
         for prop in doc.parsed_classes[class_]["class"].supportedProperty:
+            if isinstance(prop.prop, HydraLink):
+                continue
             if "vocab:" in prop.prop:
                 prop_class = prop.prop.replace("vocab:", "")
                 object_[prop.title] = gen_dummy_object(prop_class, doc)


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes https://github.com/HTTP-APIs/hydra-python-core/issues/30
Extends and improves the handling of nested class properties with the help of HydraLink.
Work in progress
Issue: Adding Link properties as GraphIII triples instead of GraphIIT triples.
Currently, it uses regex to identify links, extracts id of the nested resource and adds a GraphIII triple. I am looking for a more robust solution, I'll try out passing a list of Link properties to `crud.insert` and add a function to add GraphIII triples for GraphIII relationships defined with the help of links, so we can avoid regex and be sure about proper handling of such GraphIII relations expressed as link.
Also, need to adapt tests.

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
