### PR TITLE
Fixed authorization bug, by creating Cookie based authentication nonce

### DIFF
--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -6,7 +6,7 @@ from sqlalchemy import create_engine
 
 from gevent.pywsgi import WSGIServer
 from sqlalchemy.orm import sessionmaker
-
+from hydrus.data.db_models import User, Token, Nonce
 from hydrus.app_factory import app_factory
 from hydrus.conf import (
     HYDRUS_SERVER_URL, API_NAME, DB_URL, APIDOC_OBJ, PORT, DEBUG)
@@ -47,12 +47,13 @@ TOKEN = True
 
 if AUTH:
     try:
-        add_user(id_=1, paraphrase="test", session=session)
+        add_user(id_=5, paraphrase="test", session=session)
     except UserExists:
         pass
 
 # Create a Hydrus app
 app = app_factory(API_NAME)
+
 
 with set_authentication(app, AUTH):
     # Use authentication for all requests

--- a/hydrus/app_factory.py
+++ b/hydrus/app_factory.py
@@ -17,6 +17,7 @@ def app_factory(api_name: str = "api") -> Flask:
 
     api.add_resource(Index, "/{}/".format(api_name), endpoint="api")
     api.add_resource(Vocab, "/{}/vocab".format(api_name), endpoint="vocab")
+
     api.add_resource(
         Contexts,
         "/{}/contexts/<string:category>.jsonld".format(api_name),

--- a/hydrus/resources.py
+++ b/hydrus/resources.py
@@ -24,7 +24,7 @@ from typing import Dict, Any, Union
 from flask import Response, jsonify, request, abort
 from flask_restful import Resource
 from hydra_python_core.doc_writer import HydraStatus, HydraError
-
+from hydrus.utils import get_session
 from hydrus.auth import check_authentication_response
 from hydrus.data import crud
 from hydrus.data.exceptions import (
@@ -59,7 +59,7 @@ from hydrus.utils import (
     get_page_size,
     get_pagination)
 from hydrus.socketio_factory import socketio
-
+from hydrus.data.user import vague_Response
 
 class Index(Resource):
     """Class for the EntryPoint."""
@@ -85,6 +85,7 @@ class Entrypoint(Resource):
         response = {"@context": get_doc().entrypoint.context.generate()}
         return set_response_headers(jsonify(response))
 
+inri = False
 
 class Item(Resource):
     """Handles all operations(GET, POST, PATCH, DELETE) on Items
@@ -97,6 +98,10 @@ class Item(Resource):
         :param path : Path for Item ( Specified in APIDoc @id)
         """
         id_ = str(id_)
+
+        if not request.cookies.get("nonce"):
+            return vague_Response(path, get_session())
+
         auth_response = check_authentication_response()
         if isinstance(auth_response, Response):
             return auth_response
@@ -130,6 +135,10 @@ class Item(Resource):
         :param path - Path for Item type( Specified in APIDoc @id)
         """
         id_ = str(id_)
+
+        if not request.cookies.get("nonce"):
+            return vague_Response(path, get_session())
+
         auth_response = check_authentication_response()
         if isinstance(auth_response, Response):
             return auth_response
@@ -184,6 +193,10 @@ class Item(Resource):
         :param path - Path for Item type( Specified in APIDoc @id) to be updated
         """
         id_ = str(id_)
+
+        if not request.cookies.get("nonce"):
+            return vague_Response(path, get_session())
+
         auth_response = check_authentication_response()
         if isinstance(auth_response, Response):
             return auth_response
@@ -222,6 +235,10 @@ class Item(Resource):
     def delete(self, id_: str, path: str) -> Response:
         """Delete object with id=id_ from database."""
         id_ = str(id_)
+
+        if not request.cookies.get("nonce"):
+            return vague_Response(path, get_session())
+
         auth_response = check_authentication_response()
         if isinstance(auth_response, Response):
             return auth_response
@@ -264,9 +281,15 @@ class ItemCollection(Resource):
         Retrieve a collection of items from the database.
         """
         search_params = request.args.to_dict()
+
+
+        if not request.cookies.get("nonce"):
+            return vague_Response(path, get_session())
+
         auth_response = check_authentication_response()
         if isinstance(auth_response, Response):
             return auth_response
+
         endpoint_ = checkEndpoint("GET", path)
         if not endpoint_['method']:
             # If endpoint and Get method not supported in the API
@@ -323,6 +346,10 @@ class ItemCollection(Resource):
         Used to add an item to a collection
         :param path - Path for Item type ( Specified in APIDoc @id)
         """
+
+        if not request.cookies.get("nonce"):
+            return vague_Response(path, get_session())
+
         auth_response = check_authentication_response()
         if isinstance(auth_response, Response):
             return auth_response
@@ -398,6 +425,9 @@ class ItemCollection(Resource):
         Used to update a non-collection class.
         :param path - Path for Item type ( Specified in APIDoc @id)
         """
+        if not request.cookies.get("nonce"):
+            return vague_Response(path, get_session())
+
         auth_response = check_authentication_response()
         if isinstance(auth_response, Response):
             return auth_response
@@ -453,6 +483,10 @@ class ItemCollection(Resource):
         Used to delete a non-collection class.
         :param path - Path for Item ( Specified in APIDoc @id)
         """
+
+        if not request.cookies.get("nonce"):
+            return vague_Response(path, get_session())
+
         auth_response = check_authentication_response()
         if isinstance(auth_response, Response):
             return auth_response
@@ -492,6 +526,10 @@ class Items(Resource):
         :param int_list: Optional String containing ',' separated ID's
         :return:
         """
+
+        if not request.cookies.get("nonce"):
+            return vague_Response(path, get_session())
+
         auth_response = check_authentication_response()
         if isinstance(auth_response, Response):
             return auth_response
@@ -561,6 +599,10 @@ class Items(Resource):
         :param int_list: Optional String containing ',' separated ID's
         :return:
         """
+
+        if not request.cookies.get("nonce"):
+            return vague_Response(path, get_session())
+
         auth_response = check_authentication_response()
         if isinstance(auth_response, Response):
             return auth_response


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #430 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
The current branch uses 'X-Authentication' header to create and validate the 'nonce'.
This doesn't work as `request.headers` return Request Headers of a web page, whereas 'X-Authentication' is a part of the Response Header. 

Instead of this, storing the nonce in a cookie and giving it to client, and validating the same, at the time of authentication, works fine. Using nonce as a cookie is useful to prevent replay attacks, as the nonce is valid for only a short period of time, and once validated is converted to a token.

A new nonce cookie is generated at the time of 'failed authentication'.

### Change logs

<!-- #### Added -->
`request.set_cookie("nonce", create_nonce(session)` 
is contained by a new function named `vague_response` in `hydrus.data.user`

This function is called each time `resource.py` requests an endpoint and a cookie is not already present.
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


#### Changed

- `resource.py`
- `hydrus.data.user`

and some minor required changes.
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


 #### Removed 
`request.headers["X-Authentixation"]` and its uses
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
