### PR TITLE
change apidoc path to hydrus/samples in conf.py

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -20,6 +20,8 @@ from typing import Tuple
 import json
 import click
 import yaml
+from hydrus.conf import (
+    APIDOC_OBJ, FOUND_DOC)
 
 
 @click.command()
@@ -121,17 +123,27 @@ def startserver(adduser: Tuple, api: str, auth: bool, dburl: str, pagination: bo
                                           HYDRUS_SERVER_URL, API_NAME)
 
         except BaseException:
-            click.echo("Problem parsing specified hydradoc file, "
-                       "using sample hydradoc as default.")
-            apidoc = doc_maker.create_doc(api_document,
+            if FOUND_DOC:
+                click.echo("Problem parsing specified hydradoc file"
+                           "Using hydradoc from environment variable")
+            else:
+                click.echo("Problem parsing specified hydradoc file, "
+                           "using sample hydradoc as default.")
+
+            apidoc = doc_maker.create_doc(APIDOC_OBJ,
                                           HYDRUS_SERVER_URL, API_NAME)
     else:
-        click.echo("No hydradoc specified, using sample hydradoc as default.\n"
-                   "For creating api documentation see this "
-                   "https://www.hydraecosystem.org/01-Usage.html#newdoc\n"
-                   "You can find the example used in hydrus/samples/hydra_doc_sample.py")
+        if FOUND_DOC:
+            click.echo(
+                "No hydradoc specified, using hydradoc from environment variable as default.")
+        else:
+            click.echo("No hydradoc specified, using sample hydradoc as default.\n"
+                       "For creating api documentation see this "
+                       "https://www.hydraecosystem.org/01-Usage.html#newdoc\n"
+                       "You can find the example used in hydrus/samples/hydra_doc_sample.py")
+
         apidoc = doc_maker.create_doc(
-            api_document, HYDRUS_SERVER_URL, API_NAME)
+            APIDOC_OBJ, HYDRUS_SERVER_URL, API_NAME)
 
     # Start a session with the DB and create all classes needed by the APIDoc
     session = scoped_session(sessionmaker(bind=engine))

--- a/hydrus/conf.py
+++ b/hydrus/conf.py
@@ -6,6 +6,7 @@ Global variables are loaded or set here:
     DB_URL
     APIDOC_OBJ
     HYDRUS_SERVER_URL
+    FOUND_DOC
 """
 import os
 import logging
@@ -37,8 +38,10 @@ try:
     # try to load the path specified in environment variable
     apidoc_env = os.environ['APIDOC_REL_PATH']
     apidoc_path = cwd_path / Path(apidoc_env)
+    FOUND_DOC = True
 except KeyError:
     # if it is not set, use the example doc
+    FOUND_DOC = False
     apidoc_path = cwd_path / 'hydrus' / 'samples' / 'hydra_doc_sample.py'
 
 try:

--- a/hydrus/conf.py
+++ b/hydrus/conf.py
@@ -39,7 +39,7 @@ try:
     apidoc_path = cwd_path / Path(apidoc_env)
 except KeyError:
     # if it is not set, use the example doc
-    apidoc_path = cwd_path / 'examples' / 'drones' / 'doc.py'
+    apidoc_path = cwd_path / 'hydrus' / 'samples' / 'hydra_doc_sample.py'
 
 try:
     APIDOC_OBJ = SourceFileLoader(


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #442

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
This PR changes the apidoc_path in conf.py file to point to hydrus/samples folder to get sample hydradoc folder. Earlier apidoc_path pointed to hydradoc file in examples folder. 
### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
Changed the path of sample hydradoc from examples/drones/doc.py to hydrus/samples/hydra_doc_sample.py


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
