### PR TITLE
check in environment variables before falling back to sample doc

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -20,6 +20,8 @@ from typing import Tuple
 import json
 import click
 import yaml
+from hydrus.conf import (
+    APIDOC_OBJ, FOUND_DOC)
 
 
 @click.command()
@@ -121,17 +123,27 @@ def startserver(adduser: Tuple, api: str, auth: bool, dburl: str, pagination: bo
                                           HYDRUS_SERVER_URL, API_NAME)
 
         except BaseException:
-            click.echo("Problem parsing specified hydradoc file, "
-                       "using sample hydradoc as default.")
-            apidoc = doc_maker.create_doc(api_document,
+            if FOUND_DOC:
+                click.echo("Problem parsing specified hydradoc file"
+                           "Using hydradoc from environment variable")
+            else:
+                click.echo("Problem parsing specified hydradoc file, "
+                           "using sample hydradoc as default.")
+
+            apidoc = doc_maker.create_doc(APIDOC_OBJ,
                                           HYDRUS_SERVER_URL, API_NAME)
     else:
-        click.echo("No hydradoc specified, using sample hydradoc as default.\n"
-                   "For creating api documentation see this "
-                   "https://www.hydraecosystem.org/01-Usage.html#newdoc\n"
-                   "You can find the example used in hydrus/samples/hydra_doc_sample.py")
+        if FOUND_DOC:
+            click.echo(
+                "No hydradoc specified, using hydradoc from environment variable.")
+        else:
+            click.echo("No hydradoc specified, using sample hydradoc as default.\n"
+                       "For creating api documentation see this "
+                       "https://www.hydraecosystem.org/01-Usage.html#newdoc\n"
+                       "You can find the example used in hydrus/samples/hydra_doc_sample.py")
+
         apidoc = doc_maker.create_doc(
-            api_document, HYDRUS_SERVER_URL, API_NAME)
+            APIDOC_OBJ, HYDRUS_SERVER_URL, API_NAME)
 
     # Start a session with the DB and create all classes needed by the APIDoc
     session = scoped_session(sessionmaker(bind=engine))

--- a/hydrus/conf.py
+++ b/hydrus/conf.py
@@ -6,15 +6,13 @@ Global variables are loaded or set here:
     DB_URL
     APIDOC_OBJ
     HYDRUS_SERVER_URL
+    FOUND_DOC
 """
 import os
 import logging
-
 from os.path import abspath, dirname
 from pathlib import Path
-
 from importlib.machinery import SourceFileLoader
-
 logger = logging.getLogger(__file__)
 
 try:
@@ -24,31 +22,70 @@ except KeyError:
 
 # load form environment (as many globals as possible shall be in
 # environment configuration)
+
 PORT = int(os.environ['PORT']) if 'PORT' in dict(os.environ).keys() else 8080
 API_NAME = os.environ['API_NAME'] if 'API_NAME' in dict(os.environ).keys() else 'api'
 DB_URL = os.environ['DB_URL'] if 'DB_URL' in dict(os.environ).keys() else 'sqlite:///database.db'
 
 
-# source for the Hydra documentation file can be defined as
-# as environment variable, otherwise it falls back to the example
-# TODO: why is this a Python module instead of being a JSON-LD file?
-cwd_path = Path(dirname(dirname(abspath(__file__))))
-try:
-    # try to load the path specified in environment variable
-    apidoc_env = os.environ['APIDOC_REL_PATH']
-    apidoc_path = cwd_path / Path(apidoc_env)
-except KeyError:
-    # if it is not set, use the example doc
-    apidoc_path = cwd_path / 'examples' / 'drones' / 'doc.py'
+def get_apidoc_path():
+    """
+    Get the path of the apidoc.
 
-try:
-    APIDOC_OBJ = SourceFileLoader(
-        'doc',
-        str(apidoc_path)).load_module().doc
-    logger.info('APIDOC path loaded from: {}'.format(apidoc_path))
-except FileNotFoundError:
-    logger.critical('No Hydra ApiDoc file to load has been found at {}. '
-                    'Cannot set APIDOC_OBJ'.format(apidoc_path))
-    raise
+    :return - Tuple (path, boolean). path denotes path of the apidoc.
+    If apidoc is not present at specified path then it falls back at sample apidoc.
+    boolean is true if the apidoc is present at the specified path.
+    boolean is false if sample apidoc is being used.
+    """
+    cwd_path = Path(dirname(dirname(abspath(__file__))))
+    try:
+        apidoc_env = os.environ['APIDOC_REL_PATH']
+        apidoc_path = cwd_path / Path(apidoc_env)
+        found_doc = True
+    except KeyError:
+        found_doc = False
+        apidoc_path = cwd_path / 'hydrus' / 'samples' / 'hydra_doc_sample.py'
+    return (apidoc_path, found_doc)
 
+
+def load_apidoc(path):
+    """
+    Parses docs of .jsonld, .py, .yaml format and loads apidoc from the given path.
+
+    :param path - Path for the apidoc to be loaded
+    :return - apidoc
+    :Raises:
+        FileNotFoundError: If the wrong path of hydradoc is specified.
+        BaseException: If hydradoc is specified in wrong format.
+    """
+    path = str(path)
+    try:
+        apidoc_format = path.split(".")[-1]
+        if apidoc_format == 'jsonld':
+            with open(path, 'r') as f:
+                api_doc = json.load(f)
+        elif apidoc_format == 'py':
+            api_doc = SourceFileLoader(
+                'doc', path).load_module().doc
+        elif apidoc_format == 'yaml':
+            with open(path, 'r') as stream:
+                api_doc = parse(yaml.load(stream))
+        else:
+            raise(
+                "Error - hydradoc format not supported."
+                "The supported formats are .py, .jsonld and .yaml")
+
+        logger.info('APIDOC path loaded from: {}'.format(path))
+        return api_doc
+    except FileNotFoundError:
+        logger.critical('No Hydra ApiDoc file to load has been found at {}. '
+                        'Cannot set APIDOC_OBJ'.format(path))
+        raise
+    except BaseException:
+        logger.critical("Problem parsing specified hydradoc file")
+        raise
+
+
+(path, FOUND_DOC) = get_apidoc_path()
+APIDOC_OBJ = load_apidoc(path)
 HYDRUS_SERVER_URL = 'http://localhost:{}/'.format(PORT)


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #446, #442 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
This PR enables cli.py file to first check into environment variable before falling back onto sample hydradoc. Initially, when the cli arguement hydradoc was not passed, it used the sample hydradoc. Now it searches the environment variables, if found it uses it, if not it uses the sample hydradoc. 
### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
Ability to check into environment variables first before using sample hydradoc. 
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->
Use of hydradoc from environment variables.

<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
