### PR TITLE
change MarkupSafe version from 1.0 to 1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ greenlet==0.4.13
 itsdangerous==0.24
 Jinja2
 lifter==0.4.1
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 packaging==17.1
 pep8==1.7.1
 persisting-theory==0.2.1


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #457

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
This PR updates the MarkupSafe version from 1.0 to 1.1.1, to avoid error. Earlier it was 1.0. Now its updated to 1.1.1
### Change logs
Update MarkupSafe to 1.1.1
<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->

<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
Updated MarkupSafe from version 1.0 to 1.1.1
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->
Earlier creating docker image threw error. Now its building fine. 


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
