### PR TITLE
Convert format string to f string

### DIFF
--- a/hydrus/item_collection_helpers.py
+++ b/hydrus/item_collection_helpers.py
@@ -187,8 +187,7 @@ def item_collection_post_response(path: str) -> Response:
                         path=path)
                     send_update("POST", path)
                     headers_ = [
-                        {"Location": "{}{}/{}/".format(
-                            get_hydrus_server_url(), get_api_name(), path)}]
+                        {"Location": f"{get_hydrus_server_url()}{get_api_name()}/{path}/"}]
                     status = HydraStatus(
                         code=200, title="Object successfully added")
                     return set_response_headers(


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

related to #424 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Migrates the string formatting to use f string. This was the last instance of old `.format` string formatting in the whole codebase.
I couldn't do this change in [this](https://github.com/HTTP-APIs/hydrus/pull/461) PR as this format string had gone a [recent change](https://github.com/HTTP-APIs/hydrus/pull/463) in `develop` on to which I didn't want to rebase my commits of [this](https://github.com/HTTP-APIs/hydrus/pull/461) PR

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
