### PR TITLE
FIX: docker-compose was failing with SSL error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM tiangolo/uwsgi-nginx-flask
+FROM tiangolo/uwsgi-nginx-flask:python3.6
 # maybe we want to move to:
 # FROM tiangolo/meinheld-gunicorn-flask:python3.6
 
 MAINTAINER Akshay Dahiya <xadahiya@gmail.com>
 
 COPY ./requirements.txt requirements.txt
+# install certificates which were not installed in the base image
+RUN apt-get update && apt-get install -y ca-certificates
 RUN pip install -U pip && pip install --upgrade pip setuptools \ 
       && pip install -r requirements.txt && rm -rf *
 


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #473

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Using the previous base image, `tiangolo/uwsgi-nginx-flask`, gave
error server certificate verification.
Refer https://github.com/tiangolo/uwsgi-nginx-flask-docker/issues/181 for more details.

Also, switched base image from python3.8 to python3.6 as psycopg2 as error on building
on python3.8.
Refer https://github.com/psycopg/psycopg2/issues/858 for more details.