### PR TITLE
MANIT: Make the defaults same

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
     restart: always
     build: ./
     ports:
-      - "8000:8080"
+      - "8080:8080"
     environment:
       # - HYDRUS_SERVER_URL=http://192.168.99.100:8081/ ## For windows 10
       # - HYDRUS_SERVER_URL=http://54.169.232.177:8080/
       - DEBUG=1
-      - API_NAME=api
+      - API_NAME=serverapi
       # relative path to the ApiDoc, from the project root
       - APIDOC_REL_PATH=examples/drones/doc.py
       - DB_URL=sqlite:///database.db


### PR DESCRIPTION

<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #475

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Made the default PORT and API_NAME same for both the cases,
when hydrus is started from `hydrus serve` as well
`docker-compose up --build`.

Now default PORT is **8080** and API_NAME is **serverapi**

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
