### PR TITLE
Make db tables for each resource in apidoc

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8,7 +8,7 @@ from hydrus.utils import (set_session, set_doc, set_hydrus_server_url,
                           set_page_size, set_pagination)
 from hydrus.data import doc_parse
 from hydra_python_core import doc_maker
-from hydrus.data.db_models import Base
+from hydrus.data.db_models import Base, create_database_tables
 from hydrus.data.user import add_user
 from hydrus.data.exceptions import UserExists
 from hydrus.data.stale_records_cleanup import remove_stale_modification_records
@@ -90,7 +90,6 @@ def serve(adduser: tuple, api: str, auth: bool, dburl: str, pagination: bool,
     # See http://docs.sqlalchemy.org/en/rel_1_0/core/engines.html for more info
     # DB_URL = 'sqlite:///database.db'
     DB_URL = dburl
-
     # Define the server URL, this is what will be displayed on the Doc
     HYDRUS_SERVER_URL = f"{serverurl}:{str(port)}/"
 
@@ -103,10 +102,10 @@ def serve(adduser: tuple, api: str, auth: bool, dburl: str, pagination: bool,
     engine = create_engine(DB_URL, connect_args={'check_same_thread': False})
     # Add the required Models to the database
 
-    if use_db is False:
-        click.echo("Creating models")
-        Base.metadata.drop_all(engine)
-        Base.metadata.create_all(engine)
+    # if use_db is False:
+    #     click.echo("Creating models")
+    #     Base.metadata.drop_all(engine)
+    #     Base.metadata.create_all(engine)
     # Define the Hydra API Documentation
     # NOTE: You can use your own API Documentation and create a HydraDoc object
     # using doc_maker or you may create your own HydraDoc Documentation using
@@ -167,12 +166,15 @@ def serve(adduser: tuple, api: str, auth: bool, dburl: str, pagination: bool,
 
     # Get all the properties from the classes
     properties = doc_parse.get_all_properties(classes)
-
     # Insert them into the database
     if use_db is False:
+        Base.metadata.drop_all(engine)
         click.echo("Adding Classes and Properties")
-        doc_parse.insert_classes(classes, session)
-        doc_parse.insert_properties(properties, session)
+        create_database_tables(classes)
+        click.echo("Creating models")
+        Base.metadata.create_all(engine)
+        # doc_parse.insert_classes(classes, session)
+        # doc_parse.insert_properties(properties, session)
 
     # Add authorized users and pass if they already exist
     click.echo("Adding authorized users")

--- a/cli.py
+++ b/cli.py
@@ -100,12 +100,6 @@ def serve(adduser: tuple, api: str, auth: bool, dburl: str, pagination: bool,
     click.echo("Setting up the database")
     # Create a connection to the database you want to use
     engine = create_engine(DB_URL, connect_args={'check_same_thread': False})
-    # Add the required Models to the database
-
-    # if use_db is False:
-    #     click.echo("Creating models")
-    #     Base.metadata.drop_all(engine)
-    #     Base.metadata.create_all(engine)
     # Define the Hydra API Documentation
     # NOTE: You can use your own API Documentation and create a HydraDoc object
     # using doc_maker or you may create your own HydraDoc Documentation using
@@ -163,9 +157,6 @@ def serve(adduser: tuple, api: str, auth: bool, dburl: str, pagination: bool,
     # You can also pass dictionary defined in
     # hydra_python_core/doc_writer_sample_output.py
     classes = doc_parse.get_classes(apidoc.generate())
-
-    # Get all the properties from the classes
-    properties = doc_parse.get_all_properties(classes)
     # Insert them into the database
     if use_db is False:
         Base.metadata.drop_all(engine)
@@ -173,8 +164,6 @@ def serve(adduser: tuple, api: str, auth: bool, dburl: str, pagination: bool,
         create_database_tables(classes)
         click.echo("Creating models")
         Base.metadata.create_all(engine)
-        # doc_parse.insert_classes(classes, session)
-        # doc_parse.insert_properties(properties, session)
 
     # Add authorized users and pass if they already exist
     click.echo("Adding authorized users")

--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -269,7 +269,15 @@ def get_collection(API_NAME: str,
         "@type": f"{type_}Collection",
         "members": list()
     }  # type: Dict[str, Any]
-    filtered_instances = get_all_filtered_instances(session, search_params, type_)
+    database_search_params = copy.deepcopy(search_params)
+    pagination_parameters = ["page", "pageIndex", "limit", "offset"]
+
+    # remove pagination params before filtering in the database
+    for param in database_search_params.copy():
+        if param in pagination_parameters:
+            database_search_params.pop(param)
+
+    filtered_instances = get_all_filtered_instances(session, database_search_params, type_)
     result_length = len(filtered_instances)
     try:
         # To paginate, calculate offset and page_limit values for pagination of search results

--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -42,7 +42,8 @@ from hydrus.data.exceptions import (
 from hydrus.data.crud_helpers import (
     recreate_iri,
     attach_hydra_view,
-    pre_process_pagination_parameters
+    pre_process_pagination_parameters,
+    parse_search_params
 )
 # from sqlalchemy.orm.session import Session
 from sqlalchemy.orm.scoping import scoped_session
@@ -247,7 +248,7 @@ def get_collection(API_NAME: str,
     for param in database_search_params.copy():
         if param in pagination_parameters:
             database_search_params.pop(param)
-
+    database_search_params = parse_search_params(database_search_params)
     filtered_instances = get_all_filtered_instances(
         session, database_search_params, type_)
     collection_template = pagination(filtered_instances, path, type_, API_NAME,

--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -31,30 +31,19 @@
     typing : Module which provides support for type hints .
 
 """  # nopep8
-import re
 import copy
-from sqlalchemy.orm import with_polymorphic
-from sqlalchemy import exists
 from sqlalchemy.orm.exc import NoResultFound
 from hydrus.data.db_models import Modification
 from hydrus.data.exceptions import (
-    ClassNotFound,
     InstanceExists,
-    PropertyNotFound,
-    NotInstanceProperty,
-    NotAbstractProperty,
-    InstanceNotFound,
     PageNotFound,
     IncompatibleParameters,
     OffsetOutOfRange)
 from hydrus.data.crud_helpers import (
     recreate_iri,
     attach_hydra_view,
-    pre_process_pagination_parameters,
-    get_rdf_class,
-    get_data_iac_iii_iit,
-    add_prop_name_to_object,
-    get_instance_before_delete)
+    pre_process_pagination_parameters
+)
 # from sqlalchemy.orm.session import Session
 from sqlalchemy.orm.scoping import scoped_session
 from typing import Dict, Optional, Any, List

--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -35,8 +35,7 @@ import re
 from sqlalchemy.orm import with_polymorphic
 from sqlalchemy import exists
 from sqlalchemy.orm.exc import NoResultFound
-from hydrus.data.db_models import (Graph, BaseProperty, RDFClass, Instance,
-                                   Terminal, GraphIAC, GraphIIT, GraphIII, Modification)
+from hydrus.data.db_models import Modification
 from hydrus.data.exceptions import (
     ClassNotFound,
     InstanceExists,
@@ -54,14 +53,18 @@ from hydrus.data.crud_helpers import (
     get_rdf_class,
     get_data_iac_iii_iit,
     add_prop_name_to_object,
-    get_instance_before_delete,
-    get_all_filtered_instances)
+    get_instance_before_delete)
 # from sqlalchemy.orm.session import Session
 from sqlalchemy.orm.scoping import scoped_session
 from typing import Dict, Optional, Any, List
 
-triples = with_polymorphic(Graph, '*')
-properties = with_polymorphic(BaseProperty, "*")
+from hydrus.data.resource_based_classes import (
+    get_object,
+    insert_object,
+    update_object,
+    delete_object,
+    get_all_filtered_instances
+)
 
 
 def get(id_: str, type_: str, api_name: str, session: scoped_session,
@@ -80,12 +83,11 @@ def get(id_: str, type_: str, api_name: str, session: scoped_session,
         InstanceNotFound: If no Instance of the 'type_` class if found.
 
     """
-    object_template = {
-        "@type": "",
-    }  # type: Dict[str, Any]
-    rdf_class = get_rdf_class(session, type_)
-    object_template = add_prop_name_to_object(session, id_, object_template, rdf_class)
-    object_template["@type"] = rdf_class.name
+    query_info = {
+        "@type": type_,
+        "id_": id_
+    }
+    object_template = get_object(query_info, session)
     if path is not None:
         object_template["@id"] = f"/{api_name}/{path}Collection/{id_}"
     else:
@@ -113,66 +115,11 @@ def insert(object_: Dict[str, Any], session: scoped_session, link_props: Dict[st
             not an Instance property
         NotAbstractProperty: If any property of `object_` is a
             valid/defined RDFClass but is not a dictionary neither an Abstract Property
-
     """
-    rdf_class = None
-    instance = None
-    type_ = object_["@type"]
-    # Check for class in the beginning
-    rdf_class = get_rdf_class(session, type_)
-    if id_ is not None and session.query(exists().where(Instance.id == id_)).scalar():
-        raise InstanceExists(type_=rdf_class.name, id_=id_)
-    elif id_ is not None:
-        instance = Instance(id=id_, type_=rdf_class.id)
-    else:
-        instance = Instance(type_=rdf_class.id)
-    session.add(instance)
-    session.flush()
-
-    for prop_name in object_:
-
-        if prop_name not in ["@type", "@context"]:
-            try:
-                property_ = session.query(properties).filter(
-                    properties.name == prop_name).one()
-            except NoResultFound:
-                # Adds new Property
-                session.close()
-                raise PropertyNotFound(type_=prop_name)
-            # For insertion in III through link
-            if prop_name in link_props:
-                try:
-                    insert_iii_with_link(instance.id, property_,
-                                         link_props[prop_name], session)
-                except (NotInstanceProperty, InstanceNotFound, ClassNotFound):
-                    raise
-                continue
-            # For insertion in III
-            if isinstance(object_[prop_name], dict):
-                try:
-                    insert_iii(object_=object_, prop_name=prop_name, instance=instance,
-                               property_=property_, session=session)
-                except NotInstanceProperty:
-                    raise
-            # For insertion in IAC
-            elif session.query(exists().where(RDFClass.name == str(object_[prop_name]))).scalar() \
-                    and property_.type_ == "PROPERTY" or property_.type_ == "ABSTRACT":
-                try:
-                    insert_iac(object_=object_, prop_name=prop_name, instance=instance,
-                               property_=property_, session=session)
-                except NotAbstractProperty:
-                    raise
-
-            # For insertion in IIT
-            else:
-                try:
-                    insert_iit(object_=object_, prop_name=prop_name, instance=instance,
-                               property_=property_, session=session)
-                except NotInstanceProperty:
-                    raise
-
-    session.commit()
-    return instance.id
+    if id_ is not None:
+        object_['id'] = id_
+    inserted_object_id = insert_object(object_, session)
+    return inserted_object_id
 
 
 def insert_multiple(objects_: List[Dict[str,
@@ -237,27 +184,11 @@ def delete(id_: str, type_: str, session: scoped_session) -> None:
         InstanceNotFound: If no instace of type `type_` with id `id_` exists.
 
     """
-    instance = get_instance_before_delete(session, id_, type_)
-    data_IAC, data_III, data_IIT = get_data_iac_iii_iit(session, id_)
-    data = data_III + data_IIT + data_IAC
-    for item in data:
-        session.delete(item)
-
-    for data in data_IIT:
-        terminal = session.query(Terminal).filter(
-            Terminal.id == data.object_).one()
-        session.delete(terminal)
-
-    for data in data_III:
-        III_instance = session.query(Instance).filter(
-            Instance.id == data.object_).one()
-        III_instance_type = session.query(RDFClass).filter(
-            RDFClass.id == III_instance.type_).one()
-        # Get the III object type_
-        delete(III_instance.id, III_instance_type.name, session=session)
-
-    session.delete(instance)
-    session.commit()
+    query_info = {
+        "@type": type_,
+        "id_": id_
+    }
+    delete_object(query_info, session)
 
 
 def delete_multiple(
@@ -299,21 +230,12 @@ def update(id_: str,
     :param path: endpoint
     :return: id of updated object
     """
-    # Keep the object as fail safe
-    instance = get(id_=id_, type_=type_, session=session, api_name=api_name)
-    instance.pop("@id")
-    # Delete the old object
-    delete(id_=id_, type_=type_, session=session)
-    # Try inserting new object
-    try:
-        insert(object_=object_, id_=id_, link_props=link_props, session=session)
-    except (ClassNotFound, InstanceExists, PropertyNotFound) as e:
-        # Put old object back
-        insert(object_=instance, id_=id_, link_props=link_props, session=session)
-        raise e
-
-    get(id_=id_, type_=type_, session=session, api_name=api_name, path=path)
-    return id_
+    query_info = {
+        "@type": type_,
+        "id_": id_
+    }
+    updated_object_id = update_object(object_, query_info, session)
+    return updated_object_id
 
 
 def get_collection(API_NAME: str,
@@ -570,152 +492,3 @@ def get_modification_table_diff(session: scoped_session,
         }
         list_of_modification_records.append(modification_record)
     return list_of_modification_records
-
-
-def insert_iii(object_: Dict[str, Any], prop_name: str,
-               instance: Instance, property_: BaseProperty,
-               session: scoped_session) -> GraphIII:
-    """
-    Insert a GraphIII triple in the database.
-    :param object_:  Object body.
-    :param prop_name: Property name.
-    :param instance: Instance for the newly added object.
-    :param property_: Predicate in the new triple being inserted.
-    :param session: sqlalchemy session.
-
-    :return: GraphIII triple.
-
-    :raises: NotInstanceProperty
-    """
-    instance_id = insert(object_[prop_name], session=session)
-    instance_object = session.query(Instance).filter(
-        Instance.id == instance_id).one()
-    if property_.type_ == "PROPERTY" or property_.type_ == "INSTANCE":
-        property_.type_ = "INSTANCE"
-        session.add(property_)
-        triple = GraphIII(
-            subject=instance.id,
-            predicate=property_.id,
-            object_=instance_object.id)
-        session.add(triple)
-        return triple
-    else:
-        session.close()
-        raise NotInstanceProperty(type_=prop_name)
-
-
-def insert_iac(object_: Dict[str, Any], prop_name: str,
-               instance: Instance, property_: BaseProperty,
-               session: scoped_session) -> GraphIAC:
-    """
-    Insert a GraphIAC triple in the database.
-    :param object_:  Object body.
-    :param prop_name: Property name.
-    :param instance: Instance for the newly added object.
-    :param property_: Predicate in the new triple being inserted.
-    :param session: sqlalchemy session.
-
-    :return: GraphIAC triple.
-    """
-    if property_.type_ == "PROPERTY" or property_.type_ == "ABSTRACT":
-        property_.type_ = "ABSTRACT"
-        session.add(property_)
-        class_ = session.query(RDFClass).filter(
-            RDFClass.name == object_[prop_name]).one()
-        triple = GraphIAC(
-            subject=instance.id,
-            predicate=property_.id,
-            object_=class_.id)
-        session.add(triple)
-        return triple
-    else:
-        session.close()
-        raise NotAbstractProperty(type_=prop_name)
-
-
-def insert_iit(object_: Dict[str, Any], prop_name: str,
-               instance: Instance, property_: BaseProperty,
-               session: scoped_session) -> GraphIIT:
-    """
-    Insert a GraphIIT triple in the database.
-    :param object_:  Object body.
-    :param prop_name: Property name.
-    :param instance: Instance for the newly added object.
-    :param property_: Predicate in the new triple being inserted.
-    :param session: sqlalchemy session.
-
-    :return: GraphIIT triple.
-
-    :raises: NotInstanceProperty
-    """
-    terminal = Terminal(value=object_[prop_name])
-    session.add(terminal)
-    session.flush()  # Assigns ID without committing
-
-    if property_.type_ == "PROPERTY" or property_.type_ == "INSTANCE":
-        property_.type_ = "INSTANCE"
-        session.add(property_)
-        triple = GraphIIT(
-            subject=instance.id,
-            predicate=property_.id,
-            object_=terminal.id)
-        # Add things directly to session, if anything fails whole
-        # transaction is aborted
-        session.add(triple)
-        return triple
-    else:
-        session.close()
-        raise NotInstanceProperty(type_=prop_name)
-
-
-def insert_iii_with_link(instance_id: str, property_: BaseProperty,
-                         property_value: str, session: scoped_session):
-    """
-    Inserts GraphIII triple to store a relation defined with hydra:Link.
-    :param instance_id:  Id of the instance being inserted
-    :param property_: Property being used as predicate in the new triple.
-    :param property_value: Value of the property being inserted.
-    :param session: sqlalchemy session
-    :return:
-    """
-    if property_.type_ == "PROPERTY" or property_.type_ == "INSTANCE":
-        property_.type_ = "INSTANCE"
-        # If value matches with the regex then value is an id and link is to an
-        # instance of a collection class otherwise value is a class_type and link
-        # is to a non collection class.
-        regex = r'[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}'
-        matchObj = re.match(regex, property_value)
-        # Link is to an instance of a collection class
-        if matchObj:
-            try:
-                nested_instance = session.query(Instance).filter(
-                    Instance.id == property_value).one()
-            except NoResultFound:
-                raise InstanceNotFound(id_=property_value, type_="")
-            triple = GraphIII(
-                subject=instance_id,
-                predicate=property_.id,
-                object_=nested_instance.id)
-            session.add(triple)
-            return triple
-        # Link is to a non collection, single instance class
-        else:
-            try:
-                nested_rdf_class = session.query(RDFClass).filter(
-                    RDFClass.name == property_value).one()
-            except NoResultFound:
-                raise ClassNotFound(type_=property_value)
-            try:
-                nested_instance = session.query(Instance).filter(
-                    Instance.type_ == nested_rdf_class.id).all()[-1]
-            except (NoResultFound, IndexError, ValueError):
-                raise InstanceNotFound(type_=nested_rdf_class.name)
-            triple = GraphIII(
-                subject=instance_id,
-                predicate=property_.id,
-                object_=nested_instance.id)
-            session.add(triple)
-            return triple
-    else:
-        session.close()
-        raise NotInstanceProperty(type_=property_.name)

--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -88,11 +88,9 @@ def get(id_: str, type_: str, api_name: str, session: scoped_session,
     return object_template
 
 
-def insert(object_: Dict[str, Any], session: scoped_session, link_props: Dict[str, Any]={},
-           id_: Optional[str] = None) -> str:
+def insert(object_: Dict[str, Any], session: scoped_session, id_: Optional[str] = None) -> str:
     """Insert an object to database [POST] and returns the inserted object.
     :param object_: object to be inserted
-    :param link_props: Hydra link properties in the object.
     :param session: sqlalchemy scoped session
     :param id_: id of the object to be inserted (optional param)
     :return: ID of object inserted
@@ -118,13 +116,11 @@ def insert(object_: Dict[str, Any], session: scoped_session, link_props: Dict[st
 def insert_multiple(objects_: List[Dict[str,
                                         Any]],
                     session: scoped_session,
-                    link_props_list: List[Dict[str, Any]]=[],
                     id_: Optional[str] = "") -> List[str]:
     """
     Adds a list of object with given ids to the database
     :param objects_: List of dict's to be added to the database
     :param session: scoped session from getSession in utils
-    :param link_props_list: List of link properties for each object being inserted.
     :param id_: optional parameter containing the ids of objects that have to be inserted
     :return: Ids that have been inserted
 
@@ -147,20 +143,14 @@ def insert_multiple(objects_: List[Dict[str,
     instance_id_list = list()
 
     for index in range(len(objects_)):
-        link_props_of_object_ = dict()
         id_of_object_ = None
         object_ = objects_[index]
-        # check if link_props exist for object at that index
-        try:
-            link_props_of_object_ = link_props_list[index]
-        except IndexError:
-            pass
         # check if id_ exist for object at that index
         try:
             id_of_object_ = id_list[index]
         except IndexError:
             pass
-        inserted_object_id = insert(object_, session, link_props_of_object_, id_of_object_)
+        inserted_object_id = insert(object_, session, id_of_object_)
         instance_id_list.append(inserted_object_id)
 
     return instance_id_list
@@ -211,7 +201,6 @@ def update(id_: str,
                          str],
            session: scoped_session,
            api_name: str,
-           link_props: Dict[str, Any]={},
            path: str = None) -> str:
     """Update an object properties based on the given object [PUT].
     :param id_: if of object to be updated
@@ -219,7 +208,6 @@ def update(id_: str,
     :param object_: object that has to be inserted
     :param session: sqlalchemy scoped session
     :param api_name: api name specified while starting server
-    :param link_props: Link properties of the object being updated.
     :param path: endpoint
     :return: id of updated object
     """
@@ -366,13 +354,11 @@ def update_single(object_: Dict[str,
                                 Any],
                   session: scoped_session,
                   api_name: str,
-                  link_props: Dict[str, Any],
                   path: str = None) -> int:
     """Update instance of classes with single objects.
     :param object_: new object
     :param session: sqlalchemy scoped session
     :param api_name: api name specified while starting server
-    :param link_props: Link properties of the object being updated
     :param path: endpoint
     :return: id of the updated object
 
@@ -390,7 +376,6 @@ def update_single(object_: Dict[str,
         object_=object_,
         session=session,
         api_name=api_name,
-        link_props=link_props,
         path=path)
 
 

--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -32,6 +32,7 @@
 
 """  # nopep8
 import re
+import copy
 from sqlalchemy.orm import with_polymorphic
 from sqlalchemy import exists
 from sqlalchemy.orm.exc import NoResultFound
@@ -116,9 +117,10 @@ def insert(object_: Dict[str, Any], session: scoped_session, link_props: Dict[st
         NotAbstractProperty: If any property of `object_` is a
             valid/defined RDFClass but is not a dictionary neither an Abstract Property
     """
+    object_template = copy.deepcopy(object_)
     if id_ is not None:
-        object_['id'] = id_
-    inserted_object_id = insert_object(object_, session)
+        object_template['id'] = id_
+    inserted_object_id = insert_object(object_template, session)
     return inserted_object_id
 
 

--- a/hydrus/data/crud_helpers.py
+++ b/hydrus/data/crud_helpers.py
@@ -1,44 +1,15 @@
 # from sqlalchemy.orm.session import Session
 from sqlalchemy.orm.scoping import scoped_session
-from sqlalchemy.orm import with_polymorphic
 
 from typing import Dict, Any, Tuple
 
 from sqlalchemy.orm.exc import NoResultFound
 from hydrus.data.exceptions import (
-    ClassNotFound,
     PageNotFound,
     InvalidSearchParameter,
     IncompatibleParameters,
     OffsetOutOfRange,
-    InstanceNotFound)
-from hydrus.data.resource_based_classes import all_instances
-
-
-def apply_filter(object_id: str, search_props: Dict[str, Any],
-                 triples, session: scoped_session) -> bool:
-    """Check whether objects has properties with query values or not.
-    :param object_id: Id of the instance.
-    :param search_props: Dictionary of query parameters with property id and values.
-    :param triples: All triples.
-    :param session: sqlalchemy scoped session.
-    :return: True if the instance has properties with given values, False otherwise.
-    """
-    for prop in search_props:
-        # For nested properties
-        if isinstance(search_props[prop], dict):
-            data = session.query(triples).filter(
-                triples.GraphIII.subject == object_id, triples.GraphIII.predicate == prop).one()
-            if apply_filter(data.object_, search_props[prop], triples, session) is False:
-                return False
-        else:
-            data = session.query(triples).filter(
-                triples.GraphIIT.subject == object_id, triples.GraphIIT.predicate == prop).one()
-            terminal = session.query(Terminal).filter(
-                Terminal.id == data.object_).one()
-            if terminal.value != search_props[prop]:
-                return False
-    return True
+)
 
 
 def recreate_iri(API_NAME: str, path: str, search_params: Dict[str, Any]) -> str:
@@ -207,130 +178,3 @@ def attach_hydra_view(collection_template: Dict[str, Any], paginate_param: str,
         if page != last:
             collection_template["hydra:view"]["hydra:next"] = (
                f"{iri}{paginate_param}={page + 1}")
-
-
-def get_rdf_class(session, type_):
-    """Retrieve the RDFClass with given type_ from the database.
-    :param session: sqlalchemy scoped session
-    :param type_: type of object
-    :return: appropriate RDFClass
-
-    Raises:
-        ClassNotFound: If the `type_` is not a valid/defined RDFClass.
-    """
-    try:
-        rdf_class = session.query(RDFClass).filter(
-            RDFClass.name == type_).one()
-        return rdf_class
-    except NoResultFound:
-        raise ClassNotFound(type_=type_)
-
-
-def get_single_instance(session, id_, rdf_class):
-    """Retrieve an instance object with given ID from the database.
-    :param session: sqlalchemy scoped session
-    :param id_: id of object to be fetched
-    :return: instance object with given id_
-
-    Raises:
-        InstanceNotFound: If no Instance of the 'type_` class if found.
-    """
-    try:
-        instance = session.query(Instance).filter(
-            Instance.id == id_, Instance.type_ == rdf_class.id).one()
-        return instance
-    except NoResultFound:
-        raise InstanceNotFound(type_=rdf_class.name, id_=id_)
-
-
-def get_data_iac_iii_iit(session, id_):
-    """Get the IAC, III and IIT data from DB of a single instance given id.
-    :param session: sqlalchemy scoped session
-    :param id_: id of object to be deleted
-    :return: tuple of IAC, III and IIT data
-    """
-    data_IAC = session.query(triples).filter(triples.GraphIAC.subject == id_).all()
-    data_III = session.query(triples).filter(triples.GraphIII.subject == id_).all()
-    data_IIT = session.query(triples).filter(triples.GraphIIT.subject == id_).all()
-    return (data_IAC, data_III, data_IIT)
-
-
-def add_prop_name_to_object(session, id_, object_template, rdf_class):
-    """Add the property name to the object template.
-    :param session: sqlalchemy scoped session
-    :param id_: id of object to be fetched
-    :param object_template: a template of a the instance(dict)
-    :param rdf_class: the RDFClass of that instance
-    :return: response to the request
-    """
-    instance = get_single_instance(session, id_, rdf_class)
-    data_IAC, data_III, data_IIT = get_data_iac_iii_iit(session, id_)
-    for data in data_IAC:
-        prop_name = session.query(properties).filter(
-            properties.id == data.predicate).one().name
-        class_name = session.query(RDFClass).filter(
-            RDFClass.id == data.object_).one().name
-        object_template[prop_name] = class_name
-
-    for data in data_III:
-        prop_name = session.query(properties).filter(
-            properties.id == data.predicate).one().name
-        instance = session.query(Instance).filter(
-            Instance.id == data.object_).one()
-        object_template[prop_name] = instance.id
-
-    for data in data_IIT:
-        prop_name = session.query(properties).filter(
-            properties.id == data.predicate).one().name
-        terminal = session.query(Terminal).filter(
-            Terminal.id == data.object_).one()
-        try:
-            object_template[prop_name] = terminal.value
-        except BaseException:
-            # If terminal is none
-            object_template[prop_name] = ""
-    return object_template
-
-
-def get_instance_before_delete(session, id_, type_):
-    """Get the instance to be deleted from the database which is
-    used to delete it's IAC, III and IIT data.
-    :param session: sqlalchemy scoped session
-    :param id_: id of object to be deleted
-    :param type_: type of object to be deleted
-    :returns instance: the object instance in the database
-    Raises:
-        InstanceNotFound: If no instance of type `type_` with id `id_` exists.
-    """
-    rdf_class = get_rdf_class(session, type_)
-    try:
-        instance = session.query(Instance).filter(
-            Instance.id == id_ and type_ == rdf_class.id).one()
-        return instance
-    except NoResultFound:
-        raise InstanceNotFound(type_=rdf_class.name, id_=id_)
-
-
-def get_search_props(session, search_params):
-    """Retrieve a type of collection from the database.
-    :param session: sqlalchemy scoped session
-    :param search_params: Query parameters
-    :return: search properties(dict)
-    """
-    try:
-        # Reconstruct dict with property ids as keys
-        search_props = parse_search_params(search_params=search_params, properties=properties,
-                                           session=session)
-        return search_props
-    except InvalidSearchParameter:
-        raise
-
-
-def get_all_instances(session, type_):
-    """Get all the instances to be deleted from the database which is
-    used to delete their IAC, III and IIT data.
-    :param session: sqlalchemy scoped session
-    :param type_: type of object to be deleted
-    :returns instances: all the object instances in the database with given type
-    """
-    return all_instances(session, type_)

--- a/hydrus/data/crud_helpers.py
+++ b/hydrus/data/crud_helpers.py
@@ -14,6 +14,7 @@ from hydrus.data.exceptions import (
     InstanceNotFound)
 from hydrus.data.resource_based_classes import all_instances
 
+
 def apply_filter(object_id: str, search_props: Dict[str, Any],
                  triples, session: scoped_session) -> bool:
     """Check whether objects has properties with query values or not.

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -171,8 +171,7 @@ class Token(Base):
     expiry = Column(
         "expiry",
         DateTime,
-        default=datetime.datetime.utcnow()
-        + datetime.timedelta(seconds=EXPIRY_TIME),
+        default=datetime.datetime.utcnow() + datetime.timedelta(seconds=EXPIRY_TIME),
     )
 
     def is_valid(self):

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -1,231 +1,139 @@
 """Models for Hydra Classes."""
 
-from sqlalchemy import create_engine, ForeignKey
-from sqlalchemy.sql import func
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, String, DateTime
-from sqlalchemy.sql import func
-from typing import Any
 import datetime
 import uuid
+from sqlite3 import Connection as SQLite3Connection
+from typing import Any
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    create_engine,
+    event,
+)
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.sql import func
+
 # from hydrus.settings import DB_URL
 
-engine = create_engine('sqlite:///database.db')
+engine = create_engine("sqlite:///database.db")
 
 Base = declarative_base()  # type: Any
 
 EXPIRY_TIME = 2700  # unit: seconds
 
 
-class RDFClass(Base):
-    """Model for Classes.
-    Classes are RDF-OWL or RDF-HYDRA classes.
+# required for enforcing foreign key constraints through SQLite
+@event.listens_for(Engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    if isinstance(dbapi_connection, SQLite3Connection):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON;")
+        cursor.close()
+
+
+class Resource:
+    """
+    Class for interacting with any resource(class or collection) in the ApiDoc
     """
 
-    __tablename__ = "classes"
+    # TODO: Look for a better way to store the sql alchemy class for each resource
+    all_database_classes = {}
 
-    id = Column(
-        String,
-        default=lambda: str(
-            uuid.uuid4()),
-        unique=True,
-        primary_key=True)
-    name = Column(String, unique=True)
+    def __init__(self, resource):
+        self._resource = resource
 
-    def __repr__(self) -> str:
-        """Verbose object name."""
-        return f"<id='{self.id}', name='{self.name}'>"
+    @property
+    def name(self):
+        """Return the name of the resource from it's "@id"""
+        # split the classname at "vocab:" to get the class name
+        return self._resource["@id"].split("vocab:")[1]
 
+    @property
+    def resource(self):
+        """Return the resource dict"""
+        return self._resource
 
-class Instance(Base):
-    """Model for Object/Resource.
-    Instances are instances of some kind/classes that are served through the API.
-    """
+    @property
+    def supported_properties(self):
+        """
+        Return all the properties in "supportedProperty" property
+        of that resource.
+        """
+        return self._resource["supportedProperty"]
 
-    __tablename__ = "instances"
+    def get_attr_dict(self):
+        """
+        Return the attribute dictionary necessary for
+        creating that resource's table at runtime
+        """
+        # initialize the attribute dict with "__tablename__"
+        # and a "id" column which will act as primary key
+        # for instances of that table
+        attr_dict = {
+            "__tablename__": self.name,
+            "id": Column(
+                String,
+                default=lambda: str(uuid.uuid4()),
+                unique=True,
+                primary_key=True,
+            ),
+        }
+        for supported_property in self.supported_properties:
+            title = supported_property["title"]
+            link = supported_property["property"]
+            if type(link) is not dict:
+                if "vocab:" in link:
+                    # if vocab: is in the link, it implies that the link is pointing to
+                    # another resource in the same ApiDoc, hence make it a Foreign Key
+                    # to that resource table
+                    foreign_table_name = link.split("vocab:")[1]
+                    attr_dict[title] = Resource.foreign_key_column(
+                        foreign_table_name
+                    )
 
-    id = Column(
-        String,
-        default=lambda: str(
-            uuid.uuid4()),
-        unique=True,
-        primary_key=True)
-    type_ = Column(String, ForeignKey("classes.id"), nullable=True)
-    created = Column('created', DateTime, default=func.now())
-    last_modified = Column('last_modified', DateTime, onupdate=func.now())
+                else:
+                    attr_dict[title] = Column(String)
+            else:
+                # if the supported property has "property" attribute of @type "hydra:link"
+                if "vocab:" in link["range"]:
+                    # if vocab: is in the link["range"], it implies that the link is pointing to
+                    # another resource in the same ApiDoc, hence make it a Foreign Key
+                    # to that resource table
+                    foreign_table_name = link["range"].split("vocab:")[1]
+                    attr_dict[title] = Resource.foreign_key_column(
+                        foreign_table_name
+                    )
+                else:
+                    attr_dict[title] = Column(String)
 
+        return attr_dict
 
-class BaseProperty(Base):
-    """Model for Basic Property."""
+    @staticmethod
+    def foreign_key_column(foreign_table_name):
+        """
+        Return a sqlalchemy column which will act as
+        a foreign key to given tablename.
+        """
 
-    __tablename__ = "property"
+        return Column(
+            String,
+            ForeignKey(
+                f"{foreign_table_name}.id",
+                ondelete="CASCADE",
+                onupdate="CASCADE",
+            ),
+        )
 
-    id = Column(
-        String,
-        default=lambda: str(
-            uuid.uuid4()),
-        unique=True,
-        primary_key=True)
-    name = Column(String, unique=True, nullable=False)
-    type_ = Column(String)
-
-    __mapper_args__ = {
-        'polymorphic_on': type_,
-        'polymorphic_identity': 'PROPERTY'
-    }
-
-
-class InstanceProperty(BaseProperty):
-    """Model for Instance Properties.
-    Instance Properties are properties that are used as predicate when the subject is an Instance.
-    >>> prop1 = BaseProperty('hasWeight')
-    >>> prop2 = BaseProperty('hasCost')
-    """
-
-    __mapper_args__ = {
-        'polymorphic_identity': 'INSTANCE'
-    }
-
-    def __repr__(self) -> str:
-        """Verbose object name."""
-        return f"<id='{self.id}', name='{self.name}', type='{self.type_}'>"
-
-
-class AbstractProperty(BaseProperty):
-    """Model for Abstract Properties.
-    Abstract Properties are properties that are used as predicate between two RDF-OWL classes.
-    >>> prop1 = BaseProperty('hasWeight')
-    >>> prop2 = BaseProperty('hasCost')
-    Example of a triple:
-     RDFClass('A') Property('isSubSystemOf') RDFClass('B')
-    """
-
-    __mapper_args__ = {
-        'polymorphic_identity': 'ABSTRACT'
-    }
-
-    def __repr__(self) -> str:
-        """Verbose object name."""
-        return f"<id='{self.id}', name='{self.name}', type='{self.type_}'>"
-
-
-class Terminal(Base):
-    """Model for Terminals.
-    Terminals are numbers or string that can be referenced by a Property. They can be only
-     objects in a triple.
-    >>> t = Terminal(value=85, unit='cubic centimeters')
-    >>> t1 = Terminal(value='Cubesat', unit='standard')
-    """
-
-    __tablename__ = "terminals"
-
-    id = Column(
-        String,
-        default=lambda: str(
-            uuid.uuid4()),
-        unique=True,
-        primary_key=True)
-    value = Column(String)
-    unit = Column(String)
-
-    def __repr__(self) -> str:
-        """Verbose object name."""
-        return f"<id='{self.id}', value='{self.value}', unit='{self.unit}'>"
-
-
-class Graph(Base):
-    """Model for a graph that store triples of instance from the other models
-         to map relationships."""
-
-    __tablename__ = "graph"
-
-    id = Column(
-        String,
-        default=lambda: str(
-            uuid.uuid4()),
-        unique=True,
-        primary_key=True)
-    type = Column(String)
-
-    __mapper_args__ = {
-        'polymorphic_identity': 'graph',
-        'polymorphic_on': type
-    }
-
-
-class GraphCAC(Graph):
-    """Graph model for Class >> AbstractProperty >> Class."""
-
-    __tablename__ = 'graphcac'
-    id = Column(String, ForeignKey('graph.id'), primary_key=True)
-    subject = Column(String, ForeignKey("classes.id"))
-    predicate = Column(String, ForeignKey("property.id"))
-    object_ = Column(String, ForeignKey("classes.id"))
-
-    __mapper_args__ = {
-        'polymorphic_identity': 'graphcac',
-    }
-
-    def __repr__(self) -> str:
-        """Verbose object name."""
-        return f"<subject='{self.subject}', predicate='{self.predicate}', object_='{self.object_}'>"
-
-
-class GraphIAC(Graph):
-    """Graph model for Instance >> AbstractProperty >> Class."""
-
-    __tablename__ = 'graphiac'
-    id = Column(String, ForeignKey('graph.id'), primary_key=True, default=lambda: str(
-        uuid.uuid4()))
-    subject = Column(String, ForeignKey("instances.id"))
-    predicate = Column(String, ForeignKey("property.id"))
-    object_ = Column(String, ForeignKey("classes.id"))
-
-    __mapper_args__ = {
-        'polymorphic_identity': 'graphiac',
-    }
-
-    def __repr__(self) -> str:
-        """Verbose object name."""
-        return f"<subject='{self.subject}', predicate='{self.predicate}', object_='{self.object_}'>"
-
-
-class GraphIII(Graph):
-    """Graph model for Instance >> InstanceProperty >> Instance."""
-
-    __tablename__ = 'graphiii'
-    id = Column(String, ForeignKey('graph.id'), primary_key=True, default=lambda: str(
-        uuid.uuid4()))
-    subject = Column(String, ForeignKey("instances.id"))
-    predicate = Column(String, ForeignKey("property.id"))
-    object_ = Column(String, ForeignKey("instances.id"))
-
-    __mapper_args__ = {
-        'polymorphic_identity': 'graphiii',
-    }
-
-    def __repr__(self) -> str:
-        """Verbose object name."""
-        return f"<subject='{self.subject}', predicate='{self.predicate}', object_='{self.object_}'>"
-
-
-class GraphIIT(Graph):
-    """Graph model for Instance >> InstanceProperty >> Terminal."""
-
-    __tablename__ = 'graphiit'
-    id = Column(String, ForeignKey('graph.id'), primary_key=True, default=lambda: str(
-        uuid.uuid4()))
-    subject = Column(String, ForeignKey("instances.id"))
-    predicate = Column(String, ForeignKey("property.id"))
-    object_ = Column(String, ForeignKey("terminals.id"))
-
-    __mapper_args__ = {
-        'polymorphic_identity': 'graphiit',
-    }
-
-    def __repr__(self) -> str:
-        """Verbose object name."""
-        return f"<subject='{self.subject}', predicate='{self.predicate}', object_='{self.object_}'>"
+    def make_db_table(self):
+        """Generate the sqlalchemy table class for that resource"""
+        self.table_class = type(self.name, (Base,), self.get_attr_dict())
+        # add that class to dict for future lookups
+        Resource.all_database_classes[self.name] = self.table_class
 
 
 class Modification(Base):
@@ -233,10 +141,7 @@ class Modification(Base):
 
     __tablename__ = "modifications"
 
-    job_id = Column(
-        Integer,
-        primary_key=True,
-        autoincrement=True)
+    job_id = Column(Integer, primary_key=True, autoincrement=True)
     method = Column(String)
     resource_url = Column(String)
 
@@ -256,14 +161,18 @@ class Token(Base):
     __tablename__ = "tokens"
     id = Column(
         String,
-        default=lambda: str(
-            uuid.uuid4()),
+        default=lambda: str(uuid.uuid4()),
         unique=True,
-        primary_key=True)
-    user_id = Column(Integer, ForeignKey('user.id'))
+        primary_key=True,
+    )
+    user_id = Column(Integer, ForeignKey("user.id"))
     timestamp = Column(DateTime, default=func.now())
-    expiry = Column('expiry', DateTime, default=datetime.datetime.utcnow() +
-                    datetime.timedelta(seconds=EXPIRY_TIME))
+    expiry = Column(
+        "expiry",
+        DateTime,
+        default=datetime.datetime.utcnow()
+        + datetime.timedelta(seconds=EXPIRY_TIME),
+    )
 
     def is_valid(self):
         if self.expiry > datetime.datetime.utcnow():
@@ -277,6 +186,12 @@ class Nonce(Base):
     __tablename__ = "nonce"
     id = Column(String, primary_key=True)
     timestamp = Column(DateTime)
+
+
+def create_database_tables(classes):
+    for single_class in classes:
+        resource = Resource(single_class)
+        resource.make_db_table()
 
 
 if __name__ == "__main__":

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -93,7 +93,7 @@ class Resource:
                     # to that resource table
                     foreign_table_name = link.split("vocab:")[1]
                     attr_dict[title] = Resource.foreign_key_column(
-                        foreign_table_name
+                        foreign_table_name, title
                     )
 
                 else:
@@ -106,7 +106,7 @@ class Resource:
                     # to that resource table
                     foreign_table_name = link["range"].split("vocab:")[1]
                     attr_dict[title] = Resource.foreign_key_column(
-                        foreign_table_name
+                        foreign_table_name, title
                     )
                 else:
                     attr_dict[title] = Column(String)
@@ -114,18 +114,19 @@ class Resource:
         return attr_dict
 
     @staticmethod
-    def foreign_key_column(foreign_table_name):
+    def foreign_key_column(foreign_table_name, title):
         """
         Return a sqlalchemy column which will act as
         a foreign key to given tablename.
         """
-
+        # title is to dereference the column name later
         return Column(
             String,
             ForeignKey(
                 f"{foreign_table_name}.id",
                 ondelete="CASCADE",
                 onupdate="CASCADE",
+                info={"column_name": title},
             ),
         )
 

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -86,30 +86,16 @@ class Resource:
         for supported_property in self.supported_properties:
             title = supported_property["title"]
             link = supported_property["property"]
-            if type(link) is not dict:
-                if "vocab:" in link:
-                    # if vocab: is in the link, it implies that the link is pointing to
-                    # another resource in the same ApiDoc, hence make it a Foreign Key
-                    # to that resource table
-                    foreign_table_name = link.split("vocab:")[1]
-                    attr_dict[title] = Resource.foreign_key_column(
-                        foreign_table_name, title
-                    )
-
-                else:
-                    attr_dict[title] = Column(String)
+            if "vocab:" in link:
+                # if vocab: is in the link, it implies that the link is pointing to
+                # another resource in the same ApiDoc, hence make it a Foreign Key
+                # to that resource table
+                foreign_table_name = link.split("vocab:")[1]
+                attr_dict[title] = Resource.foreign_key_column(
+                    foreign_table_name, title
+                )
             else:
-                # if the supported property has "property" attribute of @type "hydra:link"
-                if "vocab:" in link["range"]:
-                    # if vocab: is in the link["range"], it implies that the link is pointing to
-                    # another resource in the same ApiDoc, hence make it a Foreign Key
-                    # to that resource table
-                    foreign_table_name = link["range"].split("vocab:")[1]
-                    attr_dict[title] = Resource.foreign_key_column(
-                        foreign_table_name, title
-                    )
-                else:
-                    attr_dict[title] = Column(String)
+                attr_dict[title] = Column(String)
 
         return attr_dict
 

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -118,6 +118,10 @@ class Resource:
         """
         Return a sqlalchemy column which will act as
         a foreign key to given tablename.
+        :param foreign_table_name: The table name to which the foreign key
+        relationship has to established
+        :param title: The name of this foreign key column
+        :return: A SQL-Alchemy column with correct foreign key attached
         """
         # title is to dereference the column name later
         return Column(

--- a/hydrus/data/doc_parse.py
+++ b/hydrus/data/doc_parse.py
@@ -60,16 +60,6 @@ def insert_classes(classes: List[Dict[str, Any]],
     return None
 
 
-def insert_properties(properties: Set[str],
-                      session: scoped_session) -> Optional[Any]:
-    """Insert all the properties as defined in the APIDocumentation into DB."""
-    prop_list = [BaseProperty(name=prop) for prop in properties
-                 if not session.query(exists().where(BaseProperty.name == prop)).scalar()]
-    session.add_all(prop_list)
-    session.commit()
-    return None
-
-
 # if __name__ == "__main__":
 #     Session = sessionmaker(bind=engine)
 #     session = Session()

--- a/hydrus/data/doc_parse.py
+++ b/hydrus/data/doc_parse.py
@@ -1,7 +1,6 @@
 """Parser for Hydra APIDocumentation creates Classes and Properties."""
 from sqlalchemy import exists
 
-from hydrus.data.db_models import RDFClass, BaseProperty
 from typing import Any, Dict, List, Set, Optional
 from sqlalchemy.orm.session import Session
 from sqlalchemy.orm import scoped_session

--- a/hydrus/data/exceptions.py
+++ b/hydrus/data/exceptions.py
@@ -65,32 +65,6 @@ class InstanceExists(Exception):
             return HydraError(code=400, title="Instance already exists.", desc=description)
 
 
-class NotInstanceProperty(Exception):
-    """Error when the property is not an Instance property."""
-
-    def __init__(self, type_: str) -> None:
-        """Constructor."""
-        self.type_ = type_
-
-    def get_HTTP(self) -> HydraError:
-        """Return the HTTP response for the Exception."""
-        description = f"The property {self.type_} is not an Instance property"
-        return HydraError(code=400, title="Not an Instance property", desc=description)
-
-
-class NotAbstractProperty(Exception):
-    """Error when the property is not an Abstract property."""
-
-    def __init__(self, type_: str) -> None:
-        """Constructor."""
-        self.type_ = type_
-
-    def get_HTTP(self) -> HydraError:
-        """Return the HTTP response for the Exception."""
-        description = f"The property {self.type_} is not an Abstract property"
-        return HydraError(code=400, title="Not an Abstract property", desc=description)
-
-
 class UserExists(Exception):
     """Error when the User already exitst."""
 

--- a/hydrus/data/exceptions.py
+++ b/hydrus/data/exceptions.py
@@ -148,19 +148,6 @@ class OffsetOutOfRange(Exception):
         return HydraError(code=400, title="Page not found", desc=description)
 
 
-class DatabaseConstraintError(Exception):
-    """Error when the any constraint of database is failed. For eg: Foreign Key constraint"""
-
-    def __init__(self, contraint_error: str) -> None:
-        """Constructor."""
-        self.contraint_error = contraint_error
-
-    def get_HTTP(self) -> HydraError:
-        """Return the HTTP response for the Exception."""
-        description = f"{self.contraint_error}"
-        return HydraError(code=400, title="Database constraint failed", desc=description)
-
-
 class PropertyNotGiven(Exception):
     """Error when a Property is not given."""
 

--- a/hydrus/data/exceptions.py
+++ b/hydrus/data/exceptions.py
@@ -172,3 +172,16 @@ class OffsetOutOfRange(Exception):
         """Return the HTTP response for the Exception."""
         description = f"Offset {self.offset} is out of range."
         return HydraError(code=400, title="Page not found", desc=description)
+
+
+class DatabaseConstraintError(Exception):
+    """Error when the any constraint of database is failed. For eg: Foreign Key constraint"""
+
+    def __init__(self, contraint_error: str) -> None:
+        """Constructor."""
+        self.contraint_error = contraint_error
+
+    def get_HTTP(self) -> HydraError:
+        """Return the HTTP response for the Exception."""
+        description = f"{self.contraint_error}"
+        return HydraError(code=400, title="Database constraint failed", desc=description)

--- a/hydrus/data/exceptions.py
+++ b/hydrus/data/exceptions.py
@@ -185,3 +185,16 @@ class DatabaseConstraintError(Exception):
         """Return the HTTP response for the Exception."""
         description = f"{self.contraint_error}"
         return HydraError(code=400, title="Database constraint failed", desc=description)
+
+
+class PropertyNotGiven(Exception):
+    """Error when a Property is not given."""
+
+    def __init__(self, type_: str) -> None:
+        """Constructor."""
+        self.type_ = type_
+
+    def get_HTTP(self) -> HydraError:
+        """Return the HTTP response for the Exception."""
+        description = f"The property {self.type_} is not given."
+        return HydraError(code=400, title="Property not given", desc=description)

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -52,8 +52,8 @@ def insert_object(object_: Dict[str, Any], session: scoped_session) -> str:
     database_class = get_database_class(type_)
     id_ = object_.get("id", None)
     if (
-        id_ is not None
-        and session.query(exists().where(database_class.id == id_)).scalar()
+        id_ is not None and
+        session.query(exists().where(database_class.id == id_)).scalar()
     ):
         raise InstanceExists(type_, id_)
     foreign_keys = database_class.__table__.foreign_keys

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -9,8 +9,11 @@ from sqlite3 import Connection as SQLite3Connection
 from hydra_python_core import doc_maker
 from hydrus.conf import APIDOC_OBJ
 from hydrus.data.doc_parse import get_classes
-from hydrus.data.exceptions import (ClassNotFound, InstanceNotFound,
-                                    PropertyNotFound)
+from hydrus.data.exceptions import (
+    ClassNotFound,
+    InstanceNotFound,
+    PropertyNotFound,
+)
 from sqlalchemy import Column, ForeignKey, String, create_engine, event
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
@@ -144,11 +147,6 @@ class Resource:
         Resource.all_database_classes[self.name] = self.table_class
 
 
-# single_class = classes[6]
-# resource = Resource(single_class)
-# a = resource.get_attr_dict()
-
-
 def get_type(object_):
     """Return the @type of that given object"""
     return object_["@type"]
@@ -250,35 +248,3 @@ print("Creating models....")
 Base.metadata.drop_all(engine)
 Base.metadata.create_all(engine)
 print("Done")
-
-# object_ = {
-#     "@type": "State",
-#     "Speed": "100",
-#     "Position": "101",
-#     "Direction": "102",
-#     "Battery": "103",
-#     "SensorStatus": "104",
-#     "DroneID": "105",
-# }
-
-# object_ = {
-#     "@type": "Command",
-#     "State": "3e1d8fb4-df1a-41b6-a9b4-ded0f94dc196",
-#     "DroneID": "5",
-# }
-# d = insert_object(object_)
-# query_info = {
-#     "@type": "Command",
-#     "id_": "9a57ab7-46b2-495c-9e67-644cd048efd8",
-# }
-# # d = get_object(query_info)
-# # print(d)
-# delete_object(query_info)
-# object_ = {
-#     "@type": "Command",
-#     "State": "3e1d8fb4-df1a-41b6-a9b4-ded0f94dc196",
-#     "DroneID": "18",
-# }
-# d = update_object(object_, query_info)
-
-# print(d)

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -14,10 +14,13 @@ from hydrus.data.exceptions import (
     PropertyNotGiven,
 )
 from sqlalchemy import exists
+from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.orm.exc import NoResultFound
 
+from typing import Dict, Any
 
-def get_type(object_):
+
+def get_type(object_: Dict[str, Any]) -> str:
     """
     Return the @type of that given object.
     :param object_: Dict containing object properties
@@ -26,7 +29,7 @@ def get_type(object_):
     return object_["@type"]
 
 
-def get_database_class(type_):
+def get_database_class(type_: str):
     """
     Get the sqlalchemy class object from given classname
     :param type_: The @type of a object
@@ -38,7 +41,7 @@ def get_database_class(type_):
     return database_class
 
 
-def insert_object(object_, session):
+def insert_object(object_: Dict[str, Any], session: scoped_session) -> str:
     """
     Insert the object in the database
     :param object_: Dict containing object properties
@@ -49,8 +52,8 @@ def insert_object(object_, session):
     database_class = get_database_class(type_)
     id_ = object_.get("id", None)
     if (
-        id_ is not None and session.query(
-            exists().where(database_class.id == id_)).scalar()
+        id_ is not None
+        and session.query(exists().where(database_class.id == id_)).scalar()
     ):
         raise InstanceExists(type_, id_)
     foreign_keys = database_class.__table__.foreign_keys
@@ -87,7 +90,9 @@ def insert_object(object_, session):
     return inserted_object.id
 
 
-def get_object(query_info, session):
+def get_object(
+    query_info: Dict[str, str], session: scoped_session
+) -> Dict[str, str]:
     """
     Get the object from the database
     :param query_info: Dict containing the id and @type of object that has to retrieved
@@ -113,7 +118,7 @@ def get_object(query_info, session):
     return object_template
 
 
-def delete_object(query_info, session):
+def delete_object(query_info: Dict[str, str], session: scoped_session) -> None:
     """
     Delete the object from the database
     :param query_info: Dict containing the id and @type of object that has to retrieved
@@ -137,7 +142,11 @@ def delete_object(query_info, session):
         session.rollback()
 
 
-def update_object(object_, query_info, session):
+def update_object(
+    object_: Dict[str, Any],
+    query_info: Dict[str, str],
+    session: scoped_session,
+) -> str:
     """
     Update the object from the database
     :param object_: Dict containing updated object properties
@@ -162,7 +171,9 @@ def update_object(object_, query_info, session):
     return id_
 
 
-def get_all_filtered_instances(session, search_params, type_):
+def get_all_filtered_instances(
+    session: scoped_session, search_params: Dict[str, Any], type_: str
+):
     """Get all the filtered instances of from the database
     based on given query parameters.
     :param session: sqlalchemy scoped session
@@ -182,7 +193,7 @@ def get_all_filtered_instances(session, search_params, type_):
     return filtered_instances
 
 
-def get_single_response(session, type_):
+def get_single_response(session: scoped_session, type_: str):
     """
     Get instance of classes with single objects.
     :param session: sqlalchemy scoped session

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -98,7 +98,6 @@ def delete_object(query_info, session):
     type_ = query_info["@type"]
     id_ = query_info["id_"]
     database_class = get_database_class(type_)
-    id_ = query_info["id_"]
     try:
         object_ = (
             session.query(database_class)

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -195,16 +195,18 @@ def get_all_filtered_instances(
             # build query
             for attr, value in param_value.items():
                 query = query.join(nested_param_db_class)
-                query = query.filter(getattr(nested_param_db_class, attr) == value)
+                try:
+                    query = query.filter(getattr(nested_param_db_class, attr) == value)
+                except AttributeError:
+                    raise InvalidSearchParameter(f'{param}[{attr}]')
         else:
             value = search_params[param]
-            query = query.filter(getattr(database_class, param) == value)
-    try:
-        filtered_instances = query.all()
-    except Exception as e:
-        # extract the wrong query parameter
-        wrong_query_param = e.args[0].split()[-1]
-        raise InvalidSearchParameter(wrong_query_param.strip("'"))
+            try:
+                query = query.filter(getattr(database_class, param) == value)
+            except AttributeError:
+                raise InvalidSearchParameter(f'{param}')
+
+    filtered_instances = query.all()
     return filtered_instances
 
 

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -2,149 +2,12 @@
 Script to generate the tables in hydrus database based on
 resources in the provided API Doc.
 """
-import sqlite3
-import uuid
-from sqlite3 import Connection as SQLite3Connection
-
-from hydra_python_core import doc_maker
-from hydrus.conf import APIDOC_OBJ
-from hydrus.data.doc_parse import get_classes
-from hydrus.data.exceptions import (
-    ClassNotFound,
-    InstanceNotFound,
-    PropertyNotFound,
-)
-from sqlalchemy import Column, ForeignKey, String, create_engine, event
-from sqlalchemy.engine import Engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from hydrus.data.db_models import Resource
+from hydrus.data.exceptions import (ClassNotFound, DatabaseConstraintError,
+                                    InstanceExists, InstanceNotFound,
+                                    InvalidSearchParameter, PropertyNotFound)
+from sqlalchemy import exists
 from sqlalchemy.orm.exc import NoResultFound
-
-serverurl = "http://localhost"
-port = 8080
-HYDRUS_SERVER_URL = f"{serverurl}:{str(port)}/"
-API_NAME = "serverapi"
-apidoc = doc_maker.create_doc(APIDOC_OBJ, HYDRUS_SERVER_URL, API_NAME)
-
-classes = get_classes(apidoc.generate())
-class_names = []
-
-# required for enforcing foreign key constraints through SQLite
-@event.listens_for(Engine, "connect")
-def _set_sqlite_pragma(dbapi_connection, connection_record):
-    if isinstance(dbapi_connection, SQLite3Connection):
-        cursor = dbapi_connection.cursor()
-        cursor.execute("PRAGMA foreign_keys=ON;")
-        cursor.close()
-
-
-engine = create_engine("sqlite:///database4.db")
-Base = declarative_base()
-# create a configured "Session" class
-Session = sessionmaker(bind=engine)
-
-# create a Session
-session = Session()
-
-
-class Resource:
-    """
-    Class for interacting with any resource(class or collection) in the ApiDoc
-    """
-
-    # TODO: Look for a better way to store the sql alchemy class for each resource
-    all_database_classes = {}
-
-    def __init__(self, resource):
-        self._resource = resource
-
-    @property
-    def name(self):
-        """Return the name of the resource from it's "@id"""
-        # split the classname at "vocab:" to get the class name
-        return self._resource["@id"].split("vocab:")[1]
-
-    @property
-    def resource(self):
-        """Return the resource dict"""
-        return self._resource
-
-    @property
-    def supported_properties(self):
-        """
-        Return all the properties in "supportedProperty" property
-        of that resource.
-        """
-        return self._resource["supportedProperty"]
-
-    def get_attr_dict(self):
-        """
-        Return the attribute dictionary necessary for
-        creating that resource's table at runtime
-        """
-        # initialize the attribute dict with "__tablename__"
-        # and a "id" column which will act as primary key
-        # for instances of that table
-        attr_dict = {
-            "__tablename__": self.name,
-            "id": Column(
-                String,
-                default=lambda: str(uuid.uuid4()),
-                unique=True,
-                primary_key=True,
-            ),
-        }
-        for supported_property in self.supported_properties:
-            title = supported_property["title"]
-            link = supported_property["property"]
-            if type(link) is not dict:
-                if "vocab:" in link:
-                    # if vocab: is in the link, it implies that the link is pointing to
-                    # another resource in the same ApiDoc, hence make it a Foreign Key
-                    # to that resource table
-                    foreign_table_name = link.split("vocab:")[1]
-                    attr_dict[title] = Resource.foreign_key_column(
-                        foreign_table_name
-                    )
-
-                else:
-                    attr_dict[title] = Column(String)
-            else:
-                # if the supported property has "property" attribute of @type "hydra:link"
-                if "vocab:" in link["range"]:
-                    # if vocab: is in the link["range"], it implies that the link is pointing to
-                    # another resource in the same ApiDoc, hence make it a Foreign Key
-                    # to that resource table
-                    foreign_table_name = link["range"].split("vocab:")[1]
-                    attr_dict[title] = Resource.foreign_key_column(
-                        foreign_table_name
-                    )
-                else:
-                    attr_dict[title] = Column(String)
-
-        return attr_dict
-
-    @staticmethod
-    def foreign_key_column(foreign_table_name):
-        """
-        Return a sqlalchemy column which will act as
-        a foreign key to given tablename.
-        """
-
-        return Column(
-            String,
-            ForeignKey(
-                f"{foreign_table_name}.id",
-                ondelete="CASCADE",
-                onupdate="CASCADE",
-            ),
-        )
-
-    def make_db_table(self):
-        """Generate the sqlalchemy table class for that resource"""
-        self.table_class = type(self.name, (Base,), self.get_attr_dict())
-        # add that class to dict for future lookups
-        Resource.all_database_classes[self.name] = self.table_class
 
 
 def get_type(object_):
@@ -160,13 +23,19 @@ def get_database_class(type_):
     return database_class
 
 
-def insert_object(object_):
+def insert_object(object_, session):
     """Insert the object in the database"""
     type_ = get_type(object_)
     database_class = get_database_class(type_)
+    id_ = object_.get("id", None)
     # remove the @type from object before using the object to make a
     # instance of it using sqlalchemy class
     object_.pop("@type")
+    if (
+        id_ is not None
+        and session.query(exists().where(database_class.id == id_)).scalar()
+    ):
+        raise InstanceExists(type_, id_)
     try:
         inserted_object = database_class(**object_)
     except TypeError as e:
@@ -178,12 +47,13 @@ def insert_object(object_):
         session.commit()
     except Exception as e:
         # catching any database contraint errors
+        session.rollback()
         contraint_error = e.orig
         raise DatabaseConstraintError(contraint_error)
     return inserted_object.id
 
 
-def get_object(query_info):
+def get_object(query_info, session):
     """Get the object from the database"""
     type_ = query_info["@type"]
     id_ = query_info["id_"]
@@ -203,7 +73,7 @@ def get_object(query_info):
     return object_
 
 
-def delete_object(query_info):
+def delete_object(query_info, session):
     """Delete the object from the database"""
     type_ = query_info["@type"]
     id_ = query_info["id_"]
@@ -218,33 +88,59 @@ def delete_object(query_info):
     except NoResultFound:
         raise InstanceNotFound(type_=type_, id_=id_)
     session.delete(object_)
-    session.commit()
+    try:
+        session.commit()
+    except Exception:
+        session.rollback()
 
 
-def update_object(object_, query_info):
+def update_object(object_, query_info, session):
     """Update the object from the database"""
     # Keep the object as fail safe
-    old_object = get_object(query_info)
+    old_object = get_object(query_info, session)
     # Delete the old object
-    delete_object(query_info)
+    delete_object(query_info, session)
     id_ = query_info["id_"]
     # Try inserting new object
     try:
         object_["id"] = id_
-        d = insert_object(object_)
+        d = insert_object(object_, session)
     except Exception as e:
         # Put old object back
         old_object["id"] = id_
-        d = insert_object(old_object)
+        d = insert_object(old_object, session)
         raise e
     return id_
 
 
-for single_class in classes:
-    resource = Resource(single_class)
-    resource.make_db_table()
+def all_instances(session, type_):
+    database_class = get_database_class(type_)
+    try:
+        instances = session.query(database_class).all()
+        return instances
+    except NoResultFound:
+        instances = list()
+        return instances
 
-print("Creating models....")
-Base.metadata.drop_all(engine)
-Base.metadata.create_all(engine)
-print("Done")
+
+def get_all_filtered_instances(session, search_params, type_):
+    """Get all the filtered instances of from the database
+    based on given query parameters.
+    :param session: sqlalchemy scoped session
+    :param search_params: Query parameters
+    :param type_: type of object to be deleted
+    :return: filtered instances
+    """
+    database_class = get_database_class(type_)
+    try:
+        filtered_instances = (
+            session.query(database_class).filter_by(**search_params).all()
+        )
+    except Exception as e:
+        # extract the wrong query parameter
+        import pdb
+
+        pdb.set_trace()
+        wrong_query_param = e.args[0].split()[-1]
+        raise InvalidSearchParameter(wrong_query_param.strip("'"))
+    return filtered_instances

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -3,15 +3,16 @@ Script to generate the tables in hydrus database based on
 resources in the provided API Doc.
 """
 import uuid
+from sqlite3 import Connection as SQLite3Connection
 
 from hydra_python_core import doc_maker
-from sqlalchemy import Column, String, create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
-
 from hydrus.conf import APIDOC_OBJ
 from hydrus.data.doc_parse import get_classes
 from hydrus.data.exceptions import ClassNotFound
+from sqlalchemy import Column, ForeignKey, String, create_engine, event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
 
 serverurl = "http://localhost"
 port = 8080
@@ -21,6 +22,15 @@ apidoc = doc_maker.create_doc(APIDOC_OBJ, HYDRUS_SERVER_URL, API_NAME)
 
 classes = get_classes(apidoc.generate())
 class_names = []
+
+
+@event.listens_for(Engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    if isinstance(dbapi_connection, SQLite3Connection):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON;")
+        cursor.close()
+
 
 engine = create_engine("sqlite:///database4.db")
 Base = declarative_base()
@@ -63,7 +73,33 @@ class Resource:
         }
         for supported_property in self.supported_properties:
             title = supported_property["title"]
-            attr_dict[title] = Column(String)
+            link = supported_property["property"]
+            if type(link) is not dict:
+                if "vocab:" in link:
+                    # if vocab: is in the link, it implies that the link is pointing to
+                    # another resource in the same ApiDoc, hence make it a Foreign Key
+                    # to that resource table
+                    foreign_table_name = link.split("vocab:")[1]
+                    attr_dict[title] = Column(
+                        String,
+                        ForeignKey(
+                            f"{foreign_table_name}.id",
+                            ondelete="CASCADE",
+                            onupdate="CASCADE",
+                        ),
+                    )
+                else:
+                    attr_dict[title] = Column(String)
+            else:
+                foreign_table_name = link["range"].split("vocab:")[1]
+                attr_dict[title] = Column(
+                    String,
+                    ForeignKey(
+                        f"{foreign_table_name}.id",
+                        ondelete="CASCADE",
+                        onupdate="CASCADE",
+                    ),
+                )
         return attr_dict
 
     def make_db_table(self):
@@ -71,11 +107,9 @@ class Resource:
         Resource.all_database_classes[self.name] = self.table_class
 
 
-all_database_classes = {}
-single_class = classes[2]
-resource = Resource(single_class)
-resource.make_db_table()
-# print(Resource.all_database_classes)
+# single_class = classes[6]
+# resource = Resource(single_class)
+# a = resource.get_attr_dict()
 
 
 class Object:
@@ -148,28 +182,41 @@ def update_object_from_db(object_, query_info):
     return id_
 
 
-# for single_class in classes:
-#     resource = Resource(single_class)
-#     resource.make_db_table()
+for single_class in classes:
+    resource = Resource(single_class)
+    resource.make_db_table()
 
 # print("Creating models....")
 # Base.metadata.drop_all(engine)
 # Base.metadata.create_all(engine)
 # print("Done")
 
-object_ = {
-    "@type": "Message",
-    "MessageString": "a gggg Good Message",
-}
+# object_ = {
+#     "@type": "State",
+#     "Speed": "100",
+#     "Position": "101",
+#     "Direction": "102",
+#     "Battery": "103",
+#     "SensorStatus": "104",
+#     "DroneID": "105",
+
+# }
 # data = Object(object_)
 # d = data.insert()
-query_info = {
-    "@type": "Message",
-    "id_": "007a98aa-2009-4a6b-9bc1-15bfa31027ae",
+object_ = {
+    "@type": "Command",
+    "State": "3e1d8fb4-df1a-41b6-a9b4-ded0f94dc196",
+    "DroneID": "96",
 }
+data = Object(object_)
+d = data.insert()
+# query_info = {
+#     "@type": "Message",
+#     "id_": "007a98aa-2009-4a6b-9bc1-15bfa31027ae",
+# }
 
-# d = get_object_from_db(query_info)
-# delete_object_from_db(query_info)
-d = update_object_from_db(object_, query_info)
+# # d = get_object_from_db(query_info)
+# # delete_object_from_db(query_info)
+# d = update_object_from_db(object_, query_info)
 
-print(d)
+# print(d)

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -18,12 +18,20 @@ from sqlalchemy.orm.exc import NoResultFound
 
 
 def get_type(object_):
-    """Return the @type of that given object"""
+    """
+    Return the @type of that given object.
+    :param object_: Dict containing object properties
+    :return: The @type of that object
+    """
     return object_["@type"]
 
 
 def get_database_class(type_):
-    """Get the sqlalchemy class object from given classname"""
+    """
+    Get the sqlalchemy class object from given classname
+    :param type_: The @type of a object
+    :return: The SQL-Alchemy database class object for that type_
+    """
     database_class = Resource.all_database_classes.get(type_, None)
     if database_class is None:
         raise ClassNotFound(type_)
@@ -31,7 +39,12 @@ def get_database_class(type_):
 
 
 def insert_object(object_, session):
-    """Insert the object in the database"""
+    """
+    Insert the object in the database
+    :param object_: Dict containing object properties
+    :param session: sqlalchemy session
+    :return: The ID of the inserted object
+    """
     type_ = get_type(object_)
     database_class = get_database_class(type_)
     id_ = object_.get("id", None)
@@ -75,7 +88,12 @@ def insert_object(object_, session):
 
 
 def get_object(query_info, session):
-    """Get the object from the database"""
+    """
+    Get the object from the database
+    :param query_info: Dict containing the id and @type of object that has to retrieved
+    :param session: sqlalchemy session
+    :return: dict of object with its properties
+    """
     type_ = query_info["@type"]
     id_ = query_info["id_"]
     database_class = get_database_class(type_)
@@ -96,7 +114,11 @@ def get_object(query_info, session):
 
 
 def delete_object(query_info, session):
-    """Delete the object from the database"""
+    """
+    Delete the object from the database
+    :param query_info: Dict containing the id and @type of object that has to retrieved
+    :param session: sqlalchemy session
+    """
     type_ = query_info["@type"]
     id_ = query_info["id_"]
     database_class = get_database_class(type_)
@@ -116,7 +138,13 @@ def delete_object(query_info, session):
 
 
 def update_object(object_, query_info, session):
-    """Update the object from the database"""
+    """
+    Update the object from the database
+    :param object_: Dict containing updated object properties
+    :param query_info: Dict containing the id and @type of object that has to retrieved
+    :param session: sqlalchemy session
+    :return: the ID of the updated object
+    """
     # Keep the object as fail safe
     old_object = get_object(query_info, session)
     # Delete the old object
@@ -149,7 +177,7 @@ def get_all_filtered_instances(session, search_params, type_):
     based on given query parameters.
     :param session: sqlalchemy scoped session
     :param search_params: Query parameters
-    :param type_: type of object to be deleted
+    :param type_: @type of object to be deleted
     :return: filtered instances
     """
     database_class = get_database_class(type_)
@@ -165,6 +193,12 @@ def get_all_filtered_instances(session, search_params, type_):
 
 
 def get_single_response(session, type_):
+    """
+    Get instance of classes with single objects.
+    :param session: sqlalchemy scoped session
+    :param type_: @type of object to be deleted
+    :return: instance
+    """
     database_class = get_database_class(type_)
     try:
         instance = session.query(database_class).all()[-1]

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -26,7 +26,11 @@ def get_type(object_: Dict[str, Any]) -> str:
     :param object_: Dict containing object properties
     :return: The @type of that object
     """
-    return object_["@type"]
+    try:
+        type_ = object_["@type"]
+    except TypeError:
+        raise ClassNotFound(object_)
+    return type_
 
 
 def get_database_class(type_: str):

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -14,9 +14,9 @@ from hydrus.data.exceptions import (
     PropertyNotGiven,
 )
 from sqlalchemy import exists
+from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.orm.exc import NoResultFound
-
 from typing import Dict, Any
 
 
@@ -138,7 +138,7 @@ def delete_object(query_info: Dict[str, str], session: scoped_session) -> None:
     session.delete(object_)
     try:
         session.commit()
-    except Exception:
+    except InvalidRequestError:
         session.rollback()
 
 

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -6,7 +6,6 @@ import copy
 from hydrus.data.db_models import Resource
 from hydrus.data.exceptions import (
     ClassNotFound,
-    DatabaseConstraintError,
     InstanceExists,
     InstanceNotFound,
     InvalidSearchParameter,
@@ -86,11 +85,9 @@ def insert_object(object_: Dict[str, Any], session: scoped_session) -> str:
     try:
         session.add(inserted_object)
         session.commit()
-    except Exception as e:
-        # catching any database contraint errors
+    except InvalidRequestError:
         session.rollback()
-        contraint_error = e.orig
-        raise DatabaseConstraintError(contraint_error)
+
     return inserted_object.id
 
 

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -162,16 +162,6 @@ def update_object(object_, query_info, session):
     return id_
 
 
-def all_instances(session, type_):
-    database_class = get_database_class(type_)
-    try:
-        instances = session.query(database_class).all()
-        return instances
-    except NoResultFound:
-        instances = list()
-        return instances
-
-
 def get_all_filtered_instances(session, search_params, type_):
     """Get all the filtered instances of from the database
     based on given query parameters.

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -1,0 +1,70 @@
+"""
+Script to generate the tables in hydrus database based on
+resources in the provided API Doc.
+"""
+import uuid
+
+from hydra_python_core import doc_maker
+from sqlalchemy import Column, String, create_engine
+from sqlalchemy.ext.declarative import declarative_base
+
+from hydrus.conf import APIDOC_OBJ
+from hydrus.data.doc_parse import get_classes
+
+serverurl = "http://localhost"
+port = 8080
+HYDRUS_SERVER_URL = f"{serverurl}:{str(port)}/"
+API_NAME = "serverapi"
+apidoc = doc_maker.create_doc(APIDOC_OBJ, HYDRUS_SERVER_URL, API_NAME)
+
+classes = get_classes(apidoc.generate())
+class_names = []
+
+engine = create_engine("sqlite:///database2.db")
+Base = declarative_base()
+
+
+class Resource:
+    def __init__(self, resource):
+        self._resource = resource
+
+    @property
+    def name(self):
+        # split the classname at "vocab:" to get the class name
+        return self._resource["@id"].split("vocab:")[1]
+
+    @property
+    def resource(self):
+        return self._resource
+
+    @property
+    def supported_properties(self):
+        return self._resource["supportedProperty"]
+
+    def get_attr_dict(self):
+        attr_dict = {
+            "__tablename__": self.name,
+            "id": Column(
+                String,
+                default=lambda: str(uuid.uuid4()),
+                unique=True,
+                primary_key=True,
+            ),
+        }
+        for supported_property in self.supported_properties:
+            title = supported_property["title"]
+            attr_dict[title] = Column(String)
+        return attr_dict
+
+    def make_db_table(self):
+        self.table_class = type(self.name, (Base,), self.get_attr_dict())
+
+
+for single_class in classes:
+    resource = Resource(single_class)
+    resource.make_db_table()
+
+print("Creating models....")
+Base.metadata.drop_all(engine)
+Base.metadata.create_all(engine)
+print("Done")

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import sessionmaker
 
 from hydrus.conf import APIDOC_OBJ
 from hydrus.data.doc_parse import get_classes
+from hydrus.data.exceptions import ClassNotFound
 
 serverurl = "http://localhost"
 port = 8080
@@ -21,7 +22,7 @@ apidoc = doc_maker.create_doc(APIDOC_OBJ, HYDRUS_SERVER_URL, API_NAME)
 classes = get_classes(apidoc.generate())
 class_names = []
 
-engine = create_engine("sqlite:///database1.db")
+engine = create_engine("sqlite:///database4.db")
 Base = declarative_base()
 # create a configured "Session" class
 Session = sessionmaker(bind=engine)
@@ -31,6 +32,9 @@ session = Session()
 
 
 class Resource:
+    # TODO: Look for a better way to store the sql alchemy class for each resource
+    all_database_classes = {}
+
     def __init__(self, resource):
         self._resource = resource
 
@@ -64,34 +68,84 @@ class Resource:
 
     def make_db_table(self):
         self.table_class = type(self.name, (Base,), self.get_attr_dict())
+        Resource.all_database_classes[self.name] = self.table_class
 
 
 all_database_classes = {}
 single_class = classes[2]
 resource = Resource(single_class)
 resource.make_db_table()
-all_database_classes[resource.name] = resource.table_class
-print(all_database_classes)
+# print(Resource.all_database_classes)
 
 
 class Object:
     def __init__(self, object_):
         self.object_ = object_
         self.type_ = self.get_type()
-        self.database_class = self.get_database_class()
+        self.database_class = get_database_class(self.type_)
 
     def get_type(self):
         return self.object_["@type"]
 
-    def insert_object(self):
+    def insert(self):
         self.object_.pop("@type")
-        inserted_object = self.database_class(**self.object_)
+        try:
+            inserted_object = self.database_class(**self.object_)
+        except TypeError as e:
+            # TODO: Raise PropertyNotFound exception
+            return print(e.args)
         session.add(inserted_object)
         session.commit()
-        return inserted_object
+        return inserted_object.id
 
-    def get_database_class(self):
-        return all_database_classes[self.type_]
+
+def get_database_class(type_):
+    database_class = Resource.all_database_classes.get(type_, None)
+    if database_class is None:
+        raise ClassNotFound(type_)
+    return database_class
+
+
+def get_object_from_db(query_info):
+    database_class = get_database_class(query_info["@type"])
+    id_ = query_info["id_"]
+    object_ = (
+        session.query(database_class).filter(database_class.id == id_).one()
+    ).__dict__
+    object_.pop("_sa_instance_state")
+    object_.pop("id")
+    object_["@type"] = query_info["@type"]
+    return object_
+
+
+def delete_object_from_db(query_info):
+    database_class = get_database_class(query_info["@type"])
+    id_ = query_info["id_"]
+    object_ = (
+        session.query(database_class).filter(database_class.id == id_).one()
+    )
+    session.delete(object_)
+    session.commit()
+
+
+def update_object_from_db(object_, query_info):
+    # Keep the object as fail safe
+    old_object = get_object_from_db(query_info)
+    # Delete the old object
+    delete_object_from_db(query_info)
+    id_ = query_info["id_"]
+    # Try inserting new object
+    try:
+        object_["id"] = id_
+        data = Object(object_)
+        d = data.insert()
+    except (TypeError) as e:
+        # Put old object back
+        old_object["id"] = id_
+        data = Object(old_object)
+        d = data.insert()
+        raise e
+    return id_
 
 
 # for single_class in classes:
@@ -105,8 +159,17 @@ class Object:
 
 object_ = {
     "@type": "Message",
-    "MessageString": "VV Good Message",
+    "MessageString": "a gggg Good Message",
 }
-data = Object(object_)
-d = data.insert_object()
+# data = Object(object_)
+# d = data.insert()
+query_info = {
+    "@type": "Message",
+    "id_": "007a98aa-2009-4a6b-9bc1-15bfa31027ae",
+}
+
+# d = get_object_from_db(query_info)
+# delete_object_from_db(query_info)
+d = update_object_from_db(object_, query_info)
+
 print(d)

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -36,8 +36,8 @@ def insert_object(object_, session):
     database_class = get_database_class(type_)
     id_ = object_.get("id", None)
     if (
-        id_ is not None
-        and session.query(exists().where(database_class.id == id_)).scalar()
+        id_ is not None and session.query(
+            exists().where(database_class.id == id_)).scalar()
     ):
         raise InstanceExists(type_, id_)
     foreign_keys = database_class.__table__.foreign_keys

--- a/hydrus/data/resource_based_classes.py
+++ b/hydrus/data/resource_based_classes.py
@@ -159,9 +159,6 @@ def get_all_filtered_instances(session, search_params, type_):
         )
     except Exception as e:
         # extract the wrong query parameter
-        import pdb
-
-        pdb.set_trace()
         wrong_query_param = e.args[0].split()[-1]
         raise InvalidSearchParameter(wrong_query_param.strip("'"))
     return filtered_instances

--- a/hydrus/item_collection_helpers.py
+++ b/hydrus/item_collection_helpers.py
@@ -15,7 +15,9 @@ from hydrus.data.exceptions import (
     PageNotFound,
     InvalidSearchParameter,
     OffsetOutOfRange,
-    DatabaseConstraintError)
+    DatabaseConstraintError,
+    PropertyNotGiven
+)
 
 from hydrus.helpers import (
     set_response_headers,
@@ -133,7 +135,7 @@ def item_collection_put_response(path: str) -> Response:
                 return set_response_headers(
                     jsonify(status.generate()), headers=headers_,
                     status_code=status.code)
-            except (ClassNotFound, InstanceExists, PropertyNotFound, DatabaseConstraintError) as e:
+            except (ClassNotFound, InstanceExists, PropertyNotFound, DatabaseConstraintError, PropertyNotGiven) as e:
                 error = e.get_HTTP()
                 return error_response(error)
         else:

--- a/hydrus/item_collection_helpers.py
+++ b/hydrus/item_collection_helpers.py
@@ -15,7 +15,6 @@ from hydrus.data.exceptions import (
     PageNotFound,
     InvalidSearchParameter,
     OffsetOutOfRange,
-    DatabaseConstraintError,
     PropertyNotGiven
 )
 
@@ -136,7 +135,7 @@ def item_collection_put_response(path: str) -> Response:
                     jsonify(status.generate()), headers=headers_,
                     status_code=status.code)
             except (ClassNotFound, InstanceExists, PropertyNotFound,
-                    DatabaseConstraintError, PropertyNotGiven) as e:
+                    PropertyNotGiven) as e:
                 error = e.get_HTTP()
                 return error_response(error)
         else:

--- a/hydrus/item_collection_helpers.py
+++ b/hydrus/item_collection_helpers.py
@@ -14,7 +14,8 @@ from hydrus.data.exceptions import (
     InstanceNotFound,
     PageNotFound,
     InvalidSearchParameter,
-    OffsetOutOfRange)
+    OffsetOutOfRange,
+    DatabaseConstraintError)
 
 from hydrus.helpers import (
     set_response_headers,
@@ -132,7 +133,7 @@ def item_collection_put_response(path: str) -> Response:
                 return set_response_headers(
                     jsonify(status.generate()), headers=headers_,
                     status_code=status.code)
-            except (ClassNotFound, InstanceExists, PropertyNotFound) as e:
+            except (ClassNotFound, InstanceExists, PropertyNotFound, DatabaseConstraintError) as e:
                 error = e.get_HTTP()
                 return error_response(error)
         else:

--- a/hydrus/item_collection_helpers.py
+++ b/hydrus/item_collection_helpers.py
@@ -135,7 +135,8 @@ def item_collection_put_response(path: str) -> Response:
                 return set_response_headers(
                     jsonify(status.generate()), headers=headers_,
                     status_code=status.code)
-            except (ClassNotFound, InstanceExists, PropertyNotFound, DatabaseConstraintError, PropertyNotGiven) as e:
+            except (ClassNotFound, InstanceExists, PropertyNotFound,
+                    DatabaseConstraintError, PropertyNotGiven) as e:
                 error = e.get_HTTP()
                 return error_response(error)
         else:

--- a/hydrus/item_collection_helpers.py
+++ b/hydrus/item_collection_helpers.py
@@ -150,7 +150,7 @@ def item_collection_put_response(path: str) -> Response:
         link_props, link_type_check = get_link_props(path, object_)
         if validate_object(object_, obj_type, path) and link_type_check:
             try:
-                object_id = crud.insert(object_=object_, link_props=link_props,
+                object_id = crud.insert(object_=object_,
                                         session=get_session())
                 headers_ = [{"Location": f"{get_hydrus_server_url()}{get_api_name()}/{path}/"}]
                 status = HydraStatus(
@@ -187,7 +187,6 @@ def item_collection_post_response(path: str) -> Response:
                         object_=object_,
                         session=get_session(),
                         api_name=get_api_name(),
-                        link_props=link_props,
                         path=path)
                     send_update("POST", path)
                     headers_ = [

--- a/hydrus/itemhelpers.py
+++ b/hydrus/itemhelpers.py
@@ -59,7 +59,6 @@ def items_post_check_support(id_, object_, class_path, path):
             object_id = crud.update(
                 object_=object_,
                 id_=id_,
-                link_props=link_props,
                 type_=object_["@type"],
                 session=get_session(),
                 api_name=get_api_name())
@@ -102,7 +101,6 @@ def items_put_check_support(id_, class_path, path):
         try:
             # Add the object with given ID
             object_id = crud.insert(object_=object_, id_=id_,
-                                    link_props=link_props,
                                     session=get_session())
             headers_ = [{"Location": f"{get_hydrus_server_url()}"
                                      f"{get_api_name()}/{path}/{object_id}"}]

--- a/hydrus/items_helpers.py
+++ b/hydrus/items_helpers.py
@@ -67,8 +67,7 @@ def items_put_response(path: str, int_list="") -> Response:
                 try:
                     # Insert object and return location in Header
                     object_id = crud.insert_multiple(
-                        objects_=object_, session=get_session(), id_=int_list,
-                        link_props_list=link_props_list)
+                        objects_=object_, session=get_session(), id_=int_list)
                     headers_ = [{"Location": f"{get_hydrus_server_url()}"
                                              f"{get_api_name()}/{path}/{object_id}"}]
                     if len(incomplete_objects) > 0:

--- a/hydrus/tests/conftest.py
+++ b/hydrus/tests/conftest.py
@@ -46,9 +46,13 @@ def gen_dummy_object(class_title, doc):
     for class_path in doc.parsed_classes:
         if class_title == doc.parsed_classes[class_path]["class"].title:
             for prop in doc.parsed_classes[class_path]["class"].supportedProperty:
-                if isinstance(prop.prop, HydraLink) or prop.write is False:
+                if prop.write is False:
                     continue
-                if "vocab:" in prop.prop:
+                if isinstance(prop.prop, HydraLink):
+                    prop_class = prop.prop.range.replace("vocab:", "")
+                    object_[prop.title] = gen_dummy_object(prop_class, doc)
+                    pass
+                elif "vocab:" in prop.prop:
                     prop_class = prop.prop.replace("vocab:", "")
                     object_[prop.title] = gen_dummy_object(prop_class, doc)
                 else:

--- a/hydrus/tests/conftest.py
+++ b/hydrus/tests/conftest.py
@@ -236,29 +236,18 @@ def init_db_for_app_tests(doc, constants, session, add_doc_classes_and_propertie
     Initalze the database for testing app in
     tests/functional/test_app.py.
     """
-    API_NAME = constants['API_NAME']
     for class_ in doc.parsed_classes:
         link_props = {}
         class_title = doc.parsed_classes[class_]['class'].title
-        dummy_obj = gen_dummy_object(class_title, doc)
         for supportedProp in doc.parsed_classes[class_]['class'].supportedProperty:
             if isinstance(supportedProp.prop, HydraLink):
-                class_name = supportedProp.prop.range.replace('vocab:', '')
-                for collection_path in doc.collections:
-                    coll_class = doc.collections[collection_path]['collection'].class_.title
-                    if class_name == coll_class:
-                        id_ = str(uuid.uuid4())
-                        crud.insert(
-                            gen_dummy_object(class_name, doc),
-                            id_=id_,
-                            session=session)
-                        link_props[supportedProp.title] = id_
-                        dummy_obj[supportedProp.title] = f'{API_NAME}/{collection_path}/{id_}'
-        crud.insert(dummy_obj, id_=str(uuid.uuid4()), link_props=link_props, session=session)
-        # If it's a collection class then add an extra object so
-        # we can test pagination thoroughly.
-        if class_ in doc.collections:
-            crud.insert(dummy_obj, id_=str(uuid.uuid4()), session=session)
+                dummy_obj = gen_dummy_object(class_title, doc)
+                crud.insert(dummy_obj, id_=str(uuid.uuid4()),
+                            link_props=link_props, session=session)
+                # If it's a collection class then add an extra object so
+                # we can test pagination thoroughly.
+                if class_ in doc.collections:
+                    crud.insert(dummy_obj, id_=str(uuid.uuid4()), session=session)
 
 
 @pytest.fixture()

--- a/hydrus/tests/conftest.py
+++ b/hydrus/tests/conftest.py
@@ -107,13 +107,14 @@ def engine():
 
 
 @pytest.fixture(scope='module')
-def init_db_for_auth_tests(doc, session):
+def init_db_for_auth_tests(doc, session, engine):
     """
     Initialize the database by adding the classes and properties of
     test HydraDoc object and adding a user to the database
     """
     test_classes, test_properties = get_doc_classes_and_properties(doc)
     create_database_tables(test_classes)
+    Base.metadata.create_all(engine)
     add_user(1, 'test', session)
 
 

--- a/hydrus/tests/conftest.py
+++ b/hydrus/tests/conftest.py
@@ -298,12 +298,12 @@ def socketio_client(app, session, constants, doc, socketio):
 
 
 @pytest.fixture(scope='module')
-def add_doc_classes_and_properties_to_db(doc, session):
+def add_doc_classes_and_properties_to_db(doc, session, engine):
     """
     Add the doc classes and properties to database
     for testing in /functional/test_app.py and
     /functional/test_socket.py
     """
     test_classes, test_properties = get_doc_classes_and_properties(doc)
-    doc_parse.insert_classes(test_classes, session)
-    doc_parse.insert_properties(test_properties, session)
+    create_database_tables(test_classes)
+    Base.metadata.create_all(engine)

--- a/hydrus/tests/conftest.py
+++ b/hydrus/tests/conftest.py
@@ -49,8 +49,8 @@ def gen_dummy_object(class_title, doc):
                 if prop.write is False:
                     continue
                 if isinstance(prop.prop, HydraLink):
-                    prop_class = prop.prop.range.replace("vocab:", "")
-                    object_[prop.title] = gen_dummy_object(prop_class, doc)
+                    object_[prop.title] = ''.join(random.choice(
+                        string.ascii_uppercase + string.digits) for _ in range(6))
                     pass
                 elif "vocab:" in prop.prop:
                     prop_class = prop.prop.replace("vocab:", "")
@@ -236,14 +236,12 @@ def init_db_for_app_tests(doc, constants, session, add_doc_classes_and_propertie
     """
     for class_ in doc.parsed_classes:
         class_title = doc.parsed_classes[class_]['class'].title
-        for supportedProp in doc.parsed_classes[class_]['class'].supportedProperty:
-            if isinstance(supportedProp.prop, HydraLink):
-                dummy_obj = gen_dummy_object(class_title, doc)
-                crud.insert(dummy_obj, id_=str(uuid.uuid4()), session=session)
-                # If it's a collection class then add an extra object so
-                # we can test pagination thoroughly.
-                if class_ in doc.collections:
-                    crud.insert(dummy_obj, id_=str(uuid.uuid4()), session=session)
+        dummy_obj = gen_dummy_object(class_title, doc)
+        crud.insert(dummy_obj, id_=str(uuid.uuid4()), session=session)
+        # If it's a collection class then add an extra object so
+        # we can test pagination thoroughly.
+        if class_ in doc.collections:
+            crud.insert(dummy_obj, id_=str(uuid.uuid4()), session=session)
 
 
 @pytest.fixture()

--- a/hydrus/tests/conftest.py
+++ b/hydrus/tests/conftest.py
@@ -113,7 +113,6 @@ def init_db_for_auth_tests(doc, session, engine):
     test HydraDoc object and adding a user to the database
     """
     test_classes, test_properties = get_doc_classes_and_properties(doc)
-    create_database_tables(test_classes)
     Base.metadata.create_all(engine)
     add_user(1, 'test', session)
 
@@ -294,5 +293,13 @@ def add_doc_classes_and_properties_to_db(doc, session, engine):
     /functional/test_socket.py
     """
     test_classes, test_properties = get_doc_classes_and_properties(doc)
-    create_database_tables(test_classes)
+    try:
+        create_database_tables(test_classes)
+    except Exception:
+        # catch error when the tables have been already defined.
+        # happens when /test_socket.py is run after /test_app.py
+        # in the same session
+        # in that case, no need to create the tables again on the
+        # same sqlalchemy.ext.declarative.declarative_base instance
+        pass
     Base.metadata.create_all(engine)

--- a/hydrus/tests/conftest.py
+++ b/hydrus/tests/conftest.py
@@ -203,7 +203,6 @@ def init_db_for_crud_tests(drone_doc, session, engine):
     Base.metadata.create_all(engine)
 
 
-
 @pytest.fixture(scope='module')
 def app(constants):
     """

--- a/hydrus/tests/conftest.py
+++ b/hydrus/tests/conftest.py
@@ -235,13 +235,11 @@ def init_db_for_app_tests(doc, constants, session, add_doc_classes_and_propertie
     tests/functional/test_app.py.
     """
     for class_ in doc.parsed_classes:
-        link_props = {}
         class_title = doc.parsed_classes[class_]['class'].title
         for supportedProp in doc.parsed_classes[class_]['class'].supportedProperty:
             if isinstance(supportedProp.prop, HydraLink):
                 dummy_obj = gen_dummy_object(class_title, doc)
-                crud.insert(dummy_obj, id_=str(uuid.uuid4()),
-                            link_props=link_props, session=session)
+                crud.insert(dummy_obj, id_=str(uuid.uuid4()), session=session)
                 # If it's a collection class then add an extra object so
                 # we can test pagination thoroughly.
                 if class_ in doc.collections:

--- a/hydrus/tests/functional/test_app.py
+++ b/hydrus/tests/functional/test_app.py
@@ -409,15 +409,9 @@ class TestApp():
                         assert '@type' in response_get_data
                         class_props = [x for x in class_.supportedProperty]
                         for prop_name in class_props:
-                            if isinstance(prop_name.prop, HydraLink) and prop_name.read is True:
-                                nested_obj_resp = test_app_client.get(
-                                    response_get_data[prop_name.title])
-                                assert nested_obj_resp.status_code == 200
-                                nested_obj = json.loads(
-                                    nested_obj_resp.data.decode('utf-8'))
-                                assert '@type' in nested_obj
-                            elif 'vocab:' in prop_name.prop:
-                                assert '@type' in response_get_data[prop_name.title]
+                            if not isinstance(prop_name.prop, HydraLink):
+                                if 'vocab:' in prop_name.prop:
+                                    assert '@type' in response_get_data[prop_name.title]
 
     def test_required_props(self, test_app_client, constants, doc):
         API_NAME = constants['API_NAME']

--- a/hydrus/tests/unit/test_crud.py
+++ b/hydrus/tests/unit/test_crud.py
@@ -267,7 +267,8 @@ def test_delete_multiple_id(drone_doc_collection_classes, drone_doc, session):
     assert 404 == response_code
 
 
-def test_insert_when_property_not_given(drone_doc_collection_classes, drone_doc, session, constants):
+def test_insert_when_property_not_given(drone_doc_collection_classes, drone_doc,
+                                        session, constants):
     """Test CRUD insert operation when a required foreign key
     property of that resource(column in the table) not given"""
     for class_ in drone_doc_collection_classes:

--- a/hydrus/tests/unit/test_crud.py
+++ b/hydrus/tests/unit/test_crud.py
@@ -41,18 +41,6 @@ def test_get_for_nested_obj(drone_doc_collection_classes, drone_doc, session, co
                 dummy_obj = gen_dummy_object(class_, drone_doc)
                 if isinstance(prop.prop, HydraLink):
                     nested_class = prop.prop.range.replace('vocab:', '')
-                    for collection_path in drone_doc.collections:
-                        coll_class = drone_doc.collections[
-                            collection_path]['collection'].class_.title
-                        if nested_class == coll_class:
-                            id_ = str(uuid.uuid4())
-                            crud.insert(
-                                gen_dummy_object(nested_class, drone_doc),
-                                id_=id_,
-                                session=session)
-                            link_props[prop.title] = id_
-                            dummy_obj[prop.title] = '{}/{}/{}'.format(
-                                API_NAME, collection_path, id_)
                 else:
                     nested_class = prop.prop.replace('vocab:', '')
                 obj_id = str(uuid.uuid4())
@@ -260,11 +248,12 @@ def test_delete_multiple_id(drone_doc_collection_classes, drone_doc, session):
     """Test CRUD insert when multiple ID's are given """
     objects = list()
     ids = '{},{}'.format(str(uuid.uuid4()), str(uuid.uuid4()))
+    random_class = random.choice(drone_doc_collection_classes)
     for index in range(len(ids.split(','))):
-        object = gen_dummy_object(random.choice(drone_doc_collection_classes), drone_doc)
+        object = gen_dummy_object(random_class, drone_doc)
         objects.append(object)
     insert_response = crud.insert_multiple(objects_=objects, session=session, id_=ids)
-    delete_response = crud.delete_multiple(id_=ids, type_=objects[0]['@type'], session=session)
+    delete_response = crud.delete_multiple(id_=ids, type_=random_class, session=session)
 
     response_code = None
     id_list = ids.split(',')

--- a/hydrus/tests/unit/test_crud.py
+++ b/hydrus/tests/unit/test_crud.py
@@ -265,3 +265,26 @@ def test_delete_multiple_id(drone_doc_collection_classes, drone_doc, session):
         error = e.get_HTTP()
         response_code = error.code
     assert 404 == response_code
+
+
+def test_insert_when_property_not_given(drone_doc_collection_classes, drone_doc, session, constants):
+    """Test CRUD insert operation when a required foreign key
+    property of that resource(column in the table) not given"""
+    for class_ in drone_doc_collection_classes:
+        for prop in drone_doc.parsed_classes[class_]['class'].supportedProperty:
+            if isinstance(prop.prop, HydraLink) or 'vocab:' in prop.prop:
+                dummy_obj = gen_dummy_object(class_, drone_doc)
+                if isinstance(prop.prop, HydraLink):
+                    nested_class = prop.prop.range.replace('vocab:', '')
+                else:
+                    nested_class = prop.prop.replace('vocab:', '')
+                continue
+    # remove the foreign key resource on purpose for testing
+    dummy_obj.pop(nested_class)
+    id_ = str(uuid.uuid4())
+    try:
+        insert_response = crud.insert(object_=dummy_obj, id_=id_, session=session)
+    except Exception as e:
+        error = e.get_HTTP()
+        response_code = error.code
+        assert 400 == response_code

--- a/hydrus/tests/unit/test_crud.py
+++ b/hydrus/tests/unit/test_crud.py
@@ -33,19 +33,16 @@ def test_crud_get_returns_correct_object(drone_doc_collection_classes, drone_doc
 
 def test_get_for_nested_obj(drone_doc_collection_classes, drone_doc, session, constants):
     """Test CRUD get operation for object that can contain other objects."""
-    API_NAME = constants['API_NAME']
     for class_ in drone_doc_collection_classes:
         for prop in drone_doc.parsed_classes[class_]['class'].supportedProperty:
             if isinstance(prop.prop, HydraLink) or 'vocab:' in prop.prop:
-                link_props = {}
                 dummy_obj = gen_dummy_object(class_, drone_doc)
                 if isinstance(prop.prop, HydraLink):
                     nested_class = prop.prop.range.replace('vocab:', '')
                 else:
                     nested_class = prop.prop.replace('vocab:', '')
                 obj_id = str(uuid.uuid4())
-                response = crud.insert(object_=dummy_obj, id_=obj_id,
-                                       link_props=link_props, session=session)
+                response = crud.insert(object_=dummy_obj, id_=obj_id, session=session)
                 object_ = crud.get(id_=obj_id, type_=class_, session=session,
                                    api_name='api')
                 assert prop.title in object_

--- a/hydrus/tests/unit/test_crud.py
+++ b/hydrus/tests/unit/test_crud.py
@@ -42,11 +42,11 @@ def test_get_for_nested_obj(drone_doc_collection_classes, drone_doc, session, co
                     obj_id = str(uuid.uuid4())
                     response = crud.insert(object_=dummy_obj, id_=obj_id, session=session)
                     object_ = crud.get(id_=obj_id, type_=class_, session=session,
-                                    api_name='api')
+                                       api_name='api')
                     assert prop.title in object_
                     nested_obj_id = object_[prop.title]
                     nested_obj = crud.get(id_=nested_obj_id, type_=nested_class,
-                                        session=session, api_name='api')
+                                          session=session, api_name='api')
                     assert nested_obj['@id'].split('/')[-1] == nested_obj_id
                     break
 

--- a/hydrus/tests/unit/test_crud.py
+++ b/hydrus/tests/unit/test_crud.py
@@ -35,22 +35,20 @@ def test_get_for_nested_obj(drone_doc_collection_classes, drone_doc, session, co
     """Test CRUD get operation for object that can contain other objects."""
     for class_ in drone_doc_collection_classes:
         for prop in drone_doc.parsed_classes[class_]['class'].supportedProperty:
-            if isinstance(prop.prop, HydraLink) or 'vocab:' in prop.prop:
-                dummy_obj = gen_dummy_object(class_, drone_doc)
-                if isinstance(prop.prop, HydraLink):
-                    nested_class = prop.prop.range.replace('vocab:', '')
-                else:
+            if not isinstance(prop.prop, HydraLink):
+                if 'vocab:' in prop.prop:
+                    dummy_obj = gen_dummy_object(class_, drone_doc)
                     nested_class = prop.prop.replace('vocab:', '')
-                obj_id = str(uuid.uuid4())
-                response = crud.insert(object_=dummy_obj, id_=obj_id, session=session)
-                object_ = crud.get(id_=obj_id, type_=class_, session=session,
-                                   api_name='api')
-                assert prop.title in object_
-                nested_obj_id = object_[prop.title]
-                nested_obj = crud.get(id_=nested_obj_id, type_=nested_class,
-                                      session=session, api_name='api')
-                assert nested_obj['@id'].split('/')[-1] == nested_obj_id
-                break
+                    obj_id = str(uuid.uuid4())
+                    response = crud.insert(object_=dummy_obj, id_=obj_id, session=session)
+                    object_ = crud.get(id_=obj_id, type_=class_, session=session,
+                                    api_name='api')
+                    assert prop.title in object_
+                    nested_obj_id = object_[prop.title]
+                    nested_obj = crud.get(id_=nested_obj_id, type_=nested_class,
+                                        session=session, api_name='api')
+                    assert nested_obj['@id'].split('/')[-1] == nested_obj_id
+                    break
 
 
 def test_searching_over_collection_elements(drone_doc_collection_classes, drone_doc, session):

--- a/hydrus/tests/unit/test_crud.py
+++ b/hydrus/tests/unit/test_crud.py
@@ -8,6 +8,7 @@ import uuid
 from hydra_python_core.doc_writer import HydraLink
 
 import hydrus.data.crud as crud
+from hydrus.data.exceptions import PropertyNotGiven
 from hydrus.tests.conftest import gen_dummy_object
 
 
@@ -283,7 +284,7 @@ def test_insert_when_property_not_given(drone_doc_collection_classes, drone_doc,
     id_ = str(uuid.uuid4())
     try:
         insert_response = crud.insert(object_=dummy_obj, id_=id_, session=session)
-    except Exception as e:
+    except PropertyNotGiven as e:
         error = e.get_HTTP()
         response_code = error.code
         assert 400 == response_code


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
Related #412 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
I have wrote POC code for making the database tables from parsing the API Doc.
This makes a table for each `hydra:Resource` (Classes and Collections both).
At the moment, the database schema is just a table for each resource.
The columns in each table are its all the properties in that classes / collection's `supportedProperty`.
Right now, I have just defined all these columns using the `STRING` class from sqlachemy.
There is also, a `id` column in each table acting as a primary key.

The database schema looks like, 
![image](https://user-images.githubusercontent.com/43701530/84257624-3dfe9e00-ab33-11ea-8ed6-f7dc97f424e7.png)

(I have attached the schema in the form of the SQL commands used to make that table, will update it with a proper visual schema. I did not find a tool to convert my `.db` file, to a visual schema.)
### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
