### PR TITLE
correct  template and fix no-pagination

### DIFF
--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -455,9 +455,9 @@ def pagination(filtered_instances, path, type_, API_NAME,
         collection_template["members"].append(object_template)
 
     # If pagination is disabled then stop and return the collection template
+    collection_template["hydra:totalItems"] = result_length
     if paginate is False:
         return collection_template
-    collection_template["hydra:totalItems"] = result_length
     # Calculate last page number
     if result_length != 0 and result_length % page_size == 0:
         last = result_length // page_size

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -221,8 +221,7 @@ def add_iri_template(path: str, API_NAME: str) -> Dict[str, Any]:
     :return: Hydra IriTemplate .
     """
     template_mappings = list()
-    template = f"/{API_NAME}/{path}("
-    first = True
+    template = f"/{API_NAME}/{path}{{?"
     template, template_mappings = generate_iri_mappings(path, template,
                                                         template_mapping=template_mappings,)
 
@@ -287,7 +286,7 @@ def add_pagination_iri_mappings(template: str,
     for i in range(len(paginate_variables)):
         # If final variable then do not add space and comma and add the final parentheses
         if i == len(paginate_variables) - 1:
-            template += f"{paginate_variables[i]})"
+            template += f"{paginate_variables[i]}}}"
         else:
             template += f"{paginate_variables[i]}, "
         mapping = IriTemplateMapping(variable=paginate_variables[i], prop=paginate_variables[i])

--- a/hydrus/item_collection_helpers.py
+++ b/hydrus/item_collection_helpers.py
@@ -1,6 +1,7 @@
 """Helper functions for Item Collection"""
 
 import json
+import sys
 from functools import partial
 
 from flask import Response, jsonify, request, abort
@@ -72,7 +73,7 @@ def item_collection_get_response(path: str) -> Response:
                                          page_size=get_page_size())
             else:
                 # Get whole collection
-                response = crud_response(paginate=False)
+                response = crud_response(paginate=False, page_size=sys.maxsize)
 
             response["search"] = add_iri_template(path=class_path,
                                                   API_NAME=api_name)


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #485 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
- This PR removes the error thrown on making GET request on Collection endpoints when started via cli with --no-pagination flag. 
- As we have discussed earlier, the wrong template was returned. So one minor change this PR does is that replaces parentheses by curly braces and add ? symbol to indicate key-value pairs are accepted. Ref: https://tools.ietf.org/id/draft-gregorio-uritemplate-08.html#rfc.section.3.2.8
### Change logs
- Curly braces instead of paranthesis
- Maximum possible number of members in non-paginated collection
<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
