### PR TITLE
Remove hardcoded dependencies on vocab keyword

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -156,7 +156,7 @@ def serve(adduser: tuple, api: str, auth: bool, dburl: str, pagination: bool,
     # Get all the classes from the doc
     # You can also pass dictionary defined in
     # hydra_python_core/doc_writer_sample_output.py
-    classes = doc_parse.get_classes(apidoc.generate())
+    classes = doc_parse.get_classes(apidoc)
     # Insert them into the database
     if use_db is False:
         Base.metadata.drop_all(engine)

--- a/cli.py
+++ b/cli.py
@@ -96,7 +96,6 @@ def serve(adduser: tuple, api: str, auth: bool, dburl: str, pagination: bool,
     # The name of the API or the EntryPoint, the api will be at
     # http://localhost/<API_NAME>
     API_NAME = api
-
     click.echo("Setting up the database")
     # Create a connection to the database you want to use
     engine = create_engine(DB_URL, connect_args={'check_same_thread': False})
@@ -105,7 +104,6 @@ def serve(adduser: tuple, api: str, auth: bool, dburl: str, pagination: bool,
     # using doc_maker or you may create your own HydraDoc Documentation using
     # doc_writer [see hydra_python_core/doc_writer_sample]
     click.echo("Creating the API Documentation")
-
     if hydradoc:
         # Getting hydradoc format
         # Currently supported formats [.jsonld, .py, .yaml]
@@ -176,7 +174,7 @@ def serve(adduser: tuple, api: str, auth: bool, dburl: str, pagination: bool,
 
     click.echo("Creating the application")
     # Create a Hydrus app with the API name you want, default will be "api"
-    app = app_factory(API_NAME)
+    app = app_factory(API_NAME, apidoc.doc_name)
     # Set the name of the API
     # Create a socket for the app
     socketio = create_socket(app, session)

--- a/examples/hydrus-demo-server/demo.py
+++ b/examples/hydrus-demo-server/demo.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     # Get all the classes from the doc
     # You can also pass dictionary defined in
     # hydrus/hydraspec/doc_writer_sample_output.py
-    classes = doc_parse.get_classes(apidoc.generate())
+    classes = doc_parse.get_classes(apidoc)
 
     # Get all the properties from the classes
     properties = doc_parse.get_all_properties(classes)

--- a/hydrus/app.py
+++ b/hydrus/app.py
@@ -35,7 +35,7 @@ session = sessionmaker(bind=engine)()
 # Load ApiDoc with doc_maker
 #
 apidoc = doc_maker.create_doc(APIDOC_OBJ, HYDRUS_SERVER_URL, API_NAME)
-classes = doc_parse.get_classes(apidoc.generate())
+classes = doc_parse.get_classes(apidoc)
 # Get all the properties from the classes
 properties = doc_parse.get_all_properties(classes)
 # Insert them into the database

--- a/hydrus/app_factory.py
+++ b/hydrus/app_factory.py
@@ -6,10 +6,11 @@ from hydrus.resources import (Index, Vocab, Contexts, Entrypoint,
                               ItemCollection, Item, Items)
 
 
-def app_factory(api_name: str = "api") -> Flask:
+def app_factory(api_name: str = "api", vocab_route: str = "vocab") -> Flask:
     """
     Create an app object
     :param api_name : Name of the api
+    :param vocab_route : The route at which the vocab of the apidoc is present
     :return : API with all routes directed at /[api_name].
     """
 
@@ -20,7 +21,7 @@ def app_factory(api_name: str = "api") -> Flask:
     api = Api(app)
 
     api.add_resource(Index, f"/{api_name}/", endpoint="api")
-    api.add_resource(Vocab, f"/{api_name}/vocab", endpoint="vocab")
+    api.add_resource(Vocab, f"/{api_name}/{vocab_route}", endpoint="vocab")
     api.add_resource(
         Contexts,
         f"/{api_name}/contexts/<string:category>.jsonld",

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -17,7 +17,7 @@ from sqlalchemy import (
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.sql import func
-
+from hydra_python_core.doc_writer import DocUrl
 # from hydrus.settings import DB_URL
 
 engine = create_engine("sqlite:///database.db")
@@ -50,8 +50,10 @@ class Resource:
     @property
     def name(self):
         """Return the name of the resource from it's "@id"""
-        # split the classname at "vocab:" to get the class name
-        return self._resource["@id"].split("vocab:")[1]
+        # get the base url which will be used to split the @id
+        # for eg, 'http://localhost:8080/serverapi/vocab#'
+        expanded_base_url = DocUrl.doc_url
+        return self._resource["@id"].split(expanded_base_url)[1]
 
     @property
     def resource(self):

--- a/hydrus/data/db_models.py
+++ b/hydrus/data/db_models.py
@@ -87,12 +87,13 @@ class Resource:
         }
         for supported_property in self.supported_properties:
             title = supported_property["title"]
-            link = supported_property["property"]
-            if "vocab:" in link:
-                # if vocab: is in the link, it implies that the link is pointing to
-                # another resource in the same ApiDoc, hence make it a Foreign Key
-                # to that resource table
-                foreign_table_name = link.split("vocab:")[1]
+            property_ = supported_property["property"]
+            expanded_base_url = DocUrl.doc_url
+            if expanded_base_url in property_:
+                # if expanded_base_url is in the property_, it implies that the property_
+                # is pointing to another resource in the same ApiDoc, hence make
+                # it a Foreign Key to that resource table
+                foreign_table_name = property_.split(expanded_base_url)[1]
                 attr_dict[title] = Resource.foreign_key_column(
                     foreign_table_name, title
                 )

--- a/hydrus/data/doc_parse.py
+++ b/hydrus/data/doc_parse.py
@@ -4,15 +4,17 @@ from sqlalchemy import exists
 from typing import Any, Dict, List, Set, Optional
 from sqlalchemy.orm.session import Session
 from sqlalchemy.orm import scoped_session
-# from hydrus.tests.example_doc import doc_gen
+from hydra_python_core.doc_writer import HydraDoc
 
 
-def get_classes(apidoc: Dict[str, Any]) -> List[Dict[str, Any]]:
+def get_classes(apidoc: HydraDoc) -> List[Dict[str, Any]]:
     """Get all the classes in the APIDocumentation."""
+    COLLECTION_ID = "http://www.w3.org/ns/hydra/core#Collection"
+    RESOURCE_ID = "http://www.w3.org/ns/hydra/core#Resource"
+    ENTRYPOINT_ID = apidoc.entrypoint.entrypoint.id_
     classes = list()
-    for class_ in apidoc["supportedClass"]:
-        if class_["@id"] not in ["http://www.w3.org/ns/hydra/core#Collection",
-                                 "http://www.w3.org/ns/hydra/core#Resource", "vocab:EntryPoint"]:
+    for class_ in apidoc.generate()["supportedClass"]:
+        if class_["@id"] not in [COLLECTION_ID, RESOURCE_ID, ENTRYPOINT_ID]:
             classes.append(class_)
     # print(classes)
     return classes

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -67,7 +67,8 @@ def set_response_headers(resp: Response,
         resp.headers[list(header.keys())[0]] = header[list(header.keys())[0]]
     resp.headers['Content-type'] = ct
     link = "http://www.w3.org/ns/hydra/core#apiDocumentation"
-    resp.headers['Link'] = f'<{get_hydrus_server_url()}{get_api_name()}/vocab>; rel="{link}"'
+    vocab_route = get_doc().doc_name
+    resp.headers['Link'] = f'<{get_hydrus_server_url()}{get_api_name()}/{vocab_route}>; rel="{link}"'
     return resp
 
 

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -68,7 +68,8 @@ def set_response_headers(resp: Response,
     resp.headers['Content-type'] = ct
     link = "http://www.w3.org/ns/hydra/core#apiDocumentation"
     vocab_route = get_doc().doc_name
-    resp.headers['Link'] = f'<{get_hydrus_server_url()}{get_api_name()}/{vocab_route}>; rel="{link}"'
+    link_header = f'<{get_hydrus_server_url()}{get_api_name()}/{vocab_route}>; rel="{link}"'
+    resp.headers['Link'] = link_header
     return resp
 
 

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -279,16 +279,17 @@ def generate_iri_mappings(path: str, template: str, skip_nested: bool = False,
     :return: Template string, list of template mappings and boolean showing whether
              to keep adding delimiter or not.
     """
+    expanded_base_url = DocUrl.doc_url
     for supportedProp in get_doc(
     ).parsed_classes[path]["class"].supportedProperty:
         prop_class = supportedProp.prop
         nested_class_prop = False
         if isinstance(supportedProp.prop, HydraLink):
             hydra_link = supportedProp.prop
-            prop_class = hydra_link.range.replace("vocab:", "")
+            prop_class = hydra_link.range.split(expanded_base_url)[1]
             nested_class_prop = True
-        elif "vocab:" in supportedProp.prop:
-            prop_class = supportedProp.prop.replace("vocab:", "")
+        elif expanded_base_url in supportedProp.prop:
+            prop_class = supportedProp.prop.split(expanded_base_url)[1]
             nested_class_prop = True
         if nested_class_prop and skip_nested is False:
             template, template_mapping = generate_iri_mappings(prop_class, template,

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -7,7 +7,7 @@ from hydrus.data import crud
 from hydrus.utils import get_doc, get_api_name, get_hydrus_server_url, get_session
 from hydrus.utils import get_collections_and_parsed_classes
 from hydra_python_core.doc_writer import HydraIriTemplate, IriTemplateMapping, HydraLink
-from hydra_python_core.doc_writer import HydraError
+from hydra_python_core.doc_writer import HydraError, DocUrl
 from hydrus.socketio_factory import socketio
 
 
@@ -96,11 +96,14 @@ def checkEndpoint(method: str, path: str) -> Dict[str, Union[bool, int]]:
     :return : Dict with 'method' and 'status' key
     """
     status_val = 404
-    if path == 'vocab':
+    vocab_route = get_doc().doc_name
+    if path == vocab_route:
         return {'method': False, 'status': 405}
-
+    expanded_base_url = DocUrl.doc_url
     for endpoint in get_doc().entrypoint.entrypoint.supportedProperty:
-        if path == "/".join(endpoint.id_.split("/")[1:]):
+        expanded_endpoint_id = endpoint.id_.replace("EntryPoint/", "")
+        endpoint_id = expanded_endpoint_id.split(expanded_base_url)[1]
+        if path == endpoint_id:
             status_val = 405
             for operation in endpoint.supportedOperation:
                 if operation.method == method:

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -359,6 +359,7 @@ def get_link_props(path: str, object_) -> Tuple[Dict[str, Any], bool]:
     """
     link_props = {}
     collections, parsed_classes = get_collections_and_parsed_classes()
+    expanded_base_url = DocUrl.doc_url
     if path in collections:
         # path is of a collection class
         supported_properties = get_doc().collections[path]["collection"].supportedProperty
@@ -368,7 +369,7 @@ def get_link_props(path: str, object_) -> Tuple[Dict[str, Any], bool]:
     for supportedProp in supported_properties:
         if isinstance(supportedProp.prop, HydraLink) and supportedProp.title in object_:
             prop_range = supportedProp.prop.range
-            range_class_name = prop_range.replace("vocab:", "")
+            range_class_name = prop_range.split(expanded_base_url)[1]
             for collection_path in get_doc().collections:
                 if collection_path in object_[supportedProp.title]:
                     class_title = get_doc().collections[collection_path]['collection'].class_.title

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -118,12 +118,12 @@ def getType(class_path: str, method: str) -> Any:
     :param class_path: path for the class
     :param method: Method name
     """
+    expanded_base_url = DocUrl.doc_url
     for supportedOp in get_doc(
     ).parsed_classes[class_path]["class"].supportedOperation:
         if supportedOp.method == method:
-            return supportedOp.expects.replace("vocab:", "")
-    # NOTE: Don't use split, if there are more than one substrings with
-    # 'vocab:' not everything will be returned.
+            class_type = supportedOp.expects.split(expanded_base_url)[1]
+            return class_type
 
 
 def checkClassOp(path: str, method: str) -> bool:

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -224,6 +224,7 @@ def finalize_response(path: str, obj: Dict[str, Any]) -> Dict[str, Any]:
     else:
         # path is of a non-collection class
         supported_properties = get_doc().parsed_classes[path]["class"].supportedProperty
+        expanded_base_url = DocUrl.doc_url
         for prop in supported_properties:
             # Skip not required properties which are not inserted yet.
             if not prop.required and prop.title not in obj:
@@ -232,15 +233,15 @@ def finalize_response(path: str, obj: Dict[str, Any]) -> Dict[str, Any]:
             #     obj.pop(prop.title, None)
             elif isinstance(prop.prop, HydraLink):
                 hydra_link = prop.prop
-                range_class = hydra_link.range.replace("vocab:", "")
+                range_class = hydra_link.range.split(expanded_base_url)[1]
                 nested_path, is_collection = get_nested_class_path(range_class)
                 if is_collection:
                     id = obj[prop.title]
                     obj[prop.title] = f"/{get_api_name()}/{nested_path}/{id}"
                 else:
                     obj[prop.title] = f"/{get_api_name()}/{nested_path}"
-            elif 'vocab:' in prop.prop:
-                prop_class = prop.prop.replace("vocab:", "")
+            elif expanded_base_url in prop.prop:
+                prop_class = prop.prop.split(expanded_base_url)[1]
                 id = obj[prop.title]
                 obj[prop.title] = crud.get(id, prop_class, get_api_name(), get_session())
         return obj

--- a/hydrus/items_helpers.py
+++ b/hydrus/items_helpers.py
@@ -17,7 +17,8 @@ from hydrus.helpers import (
     check_required_props,
     send_sync_update,
     get_link_props_for_multiple_objects,
-    error_response
+    error_response,
+    getType,
 )
 from hydrus.utils import (
     get_session,
@@ -42,14 +43,10 @@ def items_put_response(path: str, int_list="") -> Response:
     """
     object_ = json.loads(request.data.decode('utf-8'))
     object_ = object_["data"]
-    collections, _ = get_collections_and_parsed_classes()
-    if path in collections:
-        # If collection name in document's collections
-        collection = collections[path]["collection"]
-        # title of HydraClass object corresponding to collection
-        obj_type = collection.class_.title
-        # get path of the collection class
-        class_path = collection.class_.path
+    _, parsed_classes = get_collections_and_parsed_classes()
+    if path in parsed_classes:
+        class_path = path
+        obj_type = getType(path, "PUT")
         incomplete_objects = list()
         for obj in object_:
             if not check_required_props(class_path, obj):
@@ -104,7 +101,9 @@ def items_delete_response(path: str, int_list="") -> Response:
     :return: Appropriate response for the DELETE operation on multiple items.
     :rtype: Response
     """
-    class_type = get_doc().collections[path]["collection"].class_.title
+    _, parsed_classes = get_collections_and_parsed_classes()
+    if path in parsed_classes:
+        class_type = getType(path, "DELETE")
 
     if checkClassOp(class_type, "DELETE"):
         # Check if class_type supports PUT operation

--- a/hydrus/samples/doc_writer_sample.py
+++ b/hydrus/samples/doc_writer_sample.py
@@ -1,50 +1,74 @@
 """Sample to create Hydra APIDocumentation using doc_writer."""
 
 from hydra_python_core.doc_writer import (HydraDoc, HydraClass, HydraClassProp, HydraClassOp,
-                                          HydraStatus, HydraError, HydraLink)
+                                            HydraStatus, HydraError, HydraLink,HydraCollection)
 from typing import Any, Dict, Union
+from urllib.parse import urljoin
 
 # Creating the HydraDoc object, this is the primary class for the Doc
 API_NAME = "api"                # Name of the API, will serve as EntryPoint
-BASE_URL = "https://hydrus.com/"    # The base url at which the API is hosted
+BASE_URL = "http://hydrus.com/"    # The base url at which the API is hosted
 # NOTE: The API will be accessible at BASE_URL + ENTRY_POINT
-# (http://hydrus.com/api/)
-
+# (http://hydrus.com/api)
 # Create ApiDoc Object
 api_doc = HydraDoc(API_NAME,
                    "Title for the API Documentation",
                    "Description for the API Documentation",
                    API_NAME,
-                   BASE_URL)
+                   BASE_URL,
+                   "vocab")
 
 
 # Creating classes for the API
-class_uri = "dummyClass"      # URI of class for the HydraClass
 class_title = "dummyClass"                      # Title of the Class
 class_description = "A dummyClass for demo"     # Description of the class
-class_ = HydraClass(class_uri, class_title, class_description, endpoint=False)
+class_ = HydraClass(class_title, class_description, endpoint=False)
+
 
 # Class with single instance
-class_2_uri = "singleClass"
+
 class_2_title = "singleClass"
 class_2_description = "A non collection class"
-class_2 = HydraClass(class_2_uri, class_2_title,
-                     class_2_description, path="sc_path", endpoint=True)
+class_2 = HydraClass(class_2_title,
+                     class_2_description, endpoint=True)
 
 # Another class with single instance, will be used as nested class
 
-class_1_uri = "anotherSingleClass"
 class_1_title = "anotherSingleClass"
 class_1_description = "An another non collection class"
-class_1 = HydraClass(class_1_uri, class_1_title,
+class_1 = HydraClass(class_1_title,
                      class_1_description, endpoint=True)
 
 # Class not having any methods except put and get
-class_3_uri = "extraClass"
 class_3_title = "extraClass"
 class_3_description = "Class without any explicit methods"
-class_3 = HydraClass(class_3_uri, class_3_title,
+class_3 = HydraClass(class_3_title,
                      class_3_description, endpoint=False)
+
+collection_name = "Extraclasses"
+collection_title = "ExtraClass collection"
+collection_description = "This collection comprises of instances of ExtraClass"
+# add explicit statements about members of the collection
+# Following manages block means every member of this collection is of type class_3
+collection_managed_by = {
+    "property": "rdf:type",
+    "object": class_3.id_,
+}
+collection_1 = HydraCollection(collection_name=collection_name,
+                               collection_description=collection_description, manages=collection_managed_by, get=True,
+                               post=True, collection_path="EcTest")
+
+collection2_title = "dummyClass collection"
+collection2_name = "dummyclasses"
+collection2_description = "This collection comprises of instances of dummyClass"
+collection2_managed_by = {
+    "property": "rdf:type",
+    "object": class_.id_,
+}
+
+collection_2 = HydraCollection(collection_name=collection2_name,
+                               collection_description=collection2_description, manages=collection2_managed_by, get=True,
+                               post=True, collection_path="DcTest")
 
 # NOTE: Setting endpoint=True creates an endpoint for the class itself, this is usually for classes
 #       that have single instances.
@@ -58,16 +82,16 @@ prop1_uri = "http://props.hydrus.com/prop1"
 prop1_title = "Prop1"                   # Title of the property
 
 dummyProp1 = HydraClassProp(prop1_uri, prop1_title,
-                            required=True, read=False, write=True)
+                            required=False, read=False, write=True)
 
 
 prop2_uri = "http://props.hydrus.com/prop2"
 prop2_title = "Prop2"
 
 dummyProp2 = HydraClassProp(prop1_uri, prop2_title,
-                            required=False, read=True, write=False)
+                            required=False, read=False, write=True)
 # NOTE: Properties that are required=True must be added during class object creation
-#       Properties that are read=True are readable
+#       Properties that are read=True are read only
 #       Properties that are write=True are writable
 
 
@@ -75,12 +99,12 @@ dummyProp2 = HydraClassProp(prop1_uri, prop2_title,
 op_name = "UpdateClass"  # The name of the operation
 op_method = "POST"  # The method of the Operation [GET, POST, PUT, DELETE]
 # URI of the object that is expected for the operation
-op_expects = "vocab:dummyClass"
+op_expects = class_.id_
 op_returns = None   # URI of the object that is returned by the operation
 op_returns_header = ["Content-Type", "Content-Length"]
 op_expects_header = []
 # List of statusCode for the operation
-op_status = [HydraStatus(code=200, title="dummyClass updated.")]
+op_status = [HydraStatus(code=200, desc="dummyClass updated.")]
 
 op1 = HydraClassOp(op_name,
                    op_method,
@@ -91,41 +115,41 @@ op1 = HydraClassOp(op_name,
                    op_status)
 
 # Same way add DELETE, PUT and GET operations
-op2_status = [HydraStatus(code=200, title="dummyClass deleted.")]
+op2_status = [HydraStatus(code=200, desc="dummyClass deleted.")]
 op2 = HydraClassOp("DeleteClass", "DELETE", None, None, [], [], op2_status)
-op3_status = [HydraStatus(code=201, title="dummyClass successfully added.")]
-op3 = HydraClassOp("AddClass", "PUT", "vocab:dummyClass", None, [], [], op3_status)
-op4_status = [HydraStatus(code=200, title="dummyClass returned.")]
-op4 = HydraClassOp("GetClass", "GET", None, "vocab:dummyClass", [], [], op4_status)
+op3_status = [HydraStatus(code=201, desc="dummyClass successfully added.")]
+op3 = HydraClassOp("AddClass", "PUT", class_.id_, None, [], [], op3_status)
+op4_status = [HydraStatus(code=200, desc="dummyClass returned.")]
+op4 = HydraClassOp("GetClass", "GET", None, class_.id_, [], [], op4_status)
 
 # Operations for non collection class
-class_2_op1_status = [HydraStatus(code=200, title="singleClass changed.")]
+class_2_op1_status = [HydraStatus(code=200, desc="singleClass changed.")]
 class_2_op1 = HydraClassOp("UpdateClass", "POST",
-                           "vocab:singleClass", None, [], [], class_2_op1_status)
-class_2_op2_status = [HydraStatus(code=200, title="singleClass deleted.")]
+                           class_2.id_, None, [], [], class_2_op1_status)
+class_2_op2_status = [HydraStatus(code=200, desc="singleClass deleted.")]
 class_2_op2 = HydraClassOp("DeleteClass", "DELETE",
                            None, None, [], [], class_2_op2_status)
-class_2_op3_status = [HydraStatus(code=201, title="singleClass successfully added.")]
+class_2_op3_status = [HydraStatus(code=201, desc="singleClass successfully added.")]
 class_2_op3 = HydraClassOp(
-    "AddClass", "PUT", "vocab:singleClass", None, [], [], class_2_op3_status)
-class_2_op4_status = [HydraStatus(code=200, title="singleClass returned.")]
+    "AddClass", "PUT", class_2.id_, None, [], [], class_2_op3_status)
+class_2_op4_status = [HydraStatus(code=200, desc="singleClass returned.")]
 class_2_op4 = HydraClassOp("GetClass", "GET", None,
-                           "vocab:singleClass", [], [], class_2_op4_status)
+                           class_2.id_, [], [], class_2_op4_status)
 
-class_1_op1_status = [HydraStatus(code=200, title="anotherSingleClass returned.")]
+class_1_op1_status = [HydraStatus(code=200, desc="anotherSingleClass returned.")]
 class_1_op1 = HydraClassOp("GetClass", "GET", None,
-                           "vocab:anotherSingleClass", [], [], class_1_op1_status)
+                           class_1.id_, [], [], class_1_op1_status)
 # Add the properties to the classes
 class_.add_supported_prop(dummyProp1)
 class_.add_supported_prop(dummyProp2)
 class_2.add_supported_prop(dummyProp1)
 class_2.add_supported_prop(dummyProp2)
-dummy_prop_link = HydraLink("singleClass/dummyProp", "dummyProp", domain="vocab:singleClass",
-range_="vocab:dummyClass")
+dummy_prop_link = HydraLink("singleClass/dummyProp", "dummyProp", domain=class_2.id_,
+                            range_=class_.id_)
 class_2.add_supported_prop(HydraClassProp(
-    dummy_prop_link, "dummyProp", required=False, read=True, write=True))
+    dummy_prop_link, "dummyProp", required=False, read=False, write=True))
 class_2.add_supported_prop(HydraClassProp(
-    "vocab:anotherSingleClass", "singleClassProp", required=False, read=True, write=True))
+    class_1.id_, "singleClassProp", required=False, read=False, write=True))
 class_1.add_supported_prop(dummyProp1)
 # Add the operations to the classes
 class_.add_supported_op(op1)
@@ -139,17 +163,20 @@ class_2.add_supported_op(class_2_op4)
 class_1.add_supported_op(class_1_op1)
 
 # Add the classes to the HydraDoc
-api_doc.add_supported_class(class_, collection=True, collection_path="DcTest")
-api_doc.add_supported_class(class_3, collection=True, collection_path="EcTest")
-api_doc.add_supported_class(class_2, collection=False)
-api_doc.add_supported_class(class_1, collection=False)
-# NOTE: Using collection=True creates a HydraCollection for the class.
-#       The name of the Collection is class_.title+"Collection"
-#       The collection inherently supports GET and PUT operations
+
+api_doc.add_supported_class(class_)
+api_doc.add_supported_class(class_3)
+api_doc.add_supported_class(class_2)
+api_doc.add_supported_class(class_1)
+api_doc.add_supported_class(class_1)
+
+# add the collection to the HydraDoc.
+api_doc.add_supported_collection(collection_1)
+api_doc.add_supported_collection(collection_2)
 
 # Other operations needed for the Doc
-api_doc.add_baseResource(
-)      # Creates the base Resource Class and adds it to the API Documentation
+# Creates the base Resource Class and adds it to the API Documentation
+api_doc.add_baseResource()
 # Creates the base Collection Class and adds it to the API Documentation
 api_doc.add_baseCollection()
 # Generates the EntryPoint object for the Doc using the Classes and Collections
@@ -165,14 +192,12 @@ if __name__ == "__main__":
     import json
 
     dump = json.dumps(doc, indent=4, sort_keys=True)
-    doc = f'''""\"Generated API Documentation sample using doc_writer_sample.py.""\"
-    
-doc = {dump}
-'''
+    doc = '''"""Generated API Documentation sample using doc_writer_sample.py."""
+    \ndoc = {}\n'''.format(dump)
     # Python does not recognise null, true and false in JSON format, convert
     # them to string
     doc = doc.replace('true', '"true"')
     doc = doc.replace('false', '"false"')
     doc = doc.replace('null', '"null"')
-    with open("doc_writer_sample_output.py", "w") as f:
+    with open("samples/doc_writer_sample_output.py", "w") as f:
         f.write(doc)

--- a/hydrus/samples/doc_writer_sample_output.py
+++ b/hydrus/samples/doc_writer_sample_output.py
@@ -8,6 +8,10 @@ doc = {
             "@id": "rdfs:domain",
             "@type": "@id"
         },
+        "entrypoint": {
+            "@id": "hydra:entrypoint",
+            "@type": "@id"
+        },
         "expects": {
             "@id": "hydra:expects",
             "@type": "@id"
@@ -17,6 +21,10 @@ doc = {
         "label": "rdfs:label",
         "manages": "hydra:manages",
         "method": "hydra:method",
+        "object": {
+            "@id": "hydra:object",
+            "@type": "@id"
+        },
         "possibleStatus": "hydra:possibleStatus",
         "property": {
             "@id": "hydra:property",
@@ -35,40 +43,45 @@ doc = {
             "@type": "@id"
         },
         "returnsHeader": "hydra:returnsHeader",
+        "search": "hydra:search",
         "statusCode": "hydra:statusCode",
         "subClassOf": {
             "@id": "rdfs:subClassOf",
+            "@type": "@id"
+        },
+        "subject": {
+            "@id": "hydra:subject",
             "@type": "@id"
         },
         "supportedClass": "hydra:supportedClass",
         "supportedOperation": "hydra:supportedOperation",
         "supportedProperty": "hydra:supportedProperty",
         "title": "hydra:title",
-        "vocab": "https://hydrus.com/api/vocab#",
         "writeable": "hydra:writeable"
     },
-    "@id": "https://hydrus.com/api/vocab",
+    "@id": "http://hydrus.com/api/vocab",
     "@type": "ApiDocumentation",
     "description": "Description for the API Documentation",
+    "entrypoint": "http://hydrus.com/api",
     "possibleStatus": [],
     "supportedClass": [
         {
-            "@id": "vocab:dummyClass",
+            "@id": "http://hydrus.com/api/vocab#dummyClass",
             "@type": "hydra:Class",
             "description": "A dummyClass for demo",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/UpdateAction",
-                    "expects": "vocab:dummyClass",
+                    "expects": "http://hydrus.com/api/vocab#dummyClass",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "",
+                            "description": "dummyClass updated.",
                             "statusCode": 200,
-                            "title": "dummyClass updated."
+                            "title": ""
                         }
                     ],
                     "returns": "null",
@@ -87,9 +100,9 @@ doc = {
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "",
+                            "description": "dummyClass deleted.",
                             "statusCode": 200,
-                            "title": "dummyClass deleted."
+                            "title": ""
                         }
                     ],
                     "returns": "null",
@@ -98,16 +111,16 @@ doc = {
                 },
                 {
                     "@type": "http://schema.org/AddAction",
-                    "expects": "vocab:dummyClass",
+                    "expects": "http://hydrus.com/api/vocab#dummyClass",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "",
+                            "description": "dummyClass successfully added.",
                             "statusCode": 201,
-                            "title": "dummyClass successfully added."
+                            "title": ""
                         }
                     ],
                     "returns": "null",
@@ -123,12 +136,12 @@ doc = {
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "",
+                            "description": "dummyClass returned.",
                             "statusCode": 200,
-                            "title": "dummyClass returned."
+                            "title": ""
                         }
                     ],
-                    "returns": "vocab:dummyClass",
+                    "returns": "http://hydrus.com/api/vocab#dummyClass",
                     "returnsHeader": [],
                     "title": "GetClass"
                 }
@@ -138,23 +151,23 @@ doc = {
                     "@type": "SupportedProperty",
                     "property": "http://props.hydrus.com/prop1",
                     "readable": "false",
-                    "required": "true",
+                    "required": "false",
                     "title": "Prop1",
                     "writeable": "true"
                 },
                 {
                     "@type": "SupportedProperty",
                     "property": "http://props.hydrus.com/prop1",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "false",
                     "title": "Prop2",
-                    "writeable": "false"
+                    "writeable": "true"
                 }
             ],
             "title": "dummyClass"
         },
         {
-            "@id": "vocab:extraClass",
+            "@id": "http://hydrus.com/api/vocab#extraClass",
             "@type": "hydra:Class",
             "description": "Class without any explicit methods",
             "supportedOperation": [],
@@ -162,58 +175,22 @@ doc = {
             "title": "extraClass"
         },
         {
-            "@id": "vocab:anotherSingleClass",
-            "@type": "hydra:Class",
-            "description": "An another non collection class",
-            "supportedOperation": [
-                {
-                    "@type": "http://schema.org/FindAction",
-                    "expects": "null",
-                    "expectsHeader": [],
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                            "@type": "Status",
-                            "description": "",
-                            "statusCode": 200,
-                            "title": "anotherSingleClass returned."
-                        }
-                    ],
-                    "returns": "vocab:anotherSingleClass",
-                    "returnsHeader": [],
-                    "title": "GetClass"
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://props.hydrus.com/prop1",
-                    "readable": "false",
-                    "required": "true",
-                    "title": "Prop1",
-                    "writeable": "true"
-                }
-            ],
-            "title": "anotherSingleClass"
-        },
-        {
-            "@id": "vocab:singleClass",
+            "@id": "http://hydrus.com/api/vocab#singleClass",
             "@type": "hydra:Class",
             "description": "A non collection class",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/UpdateAction",
-                    "expects": "vocab:singleClass",
+                    "expects": "http://hydrus.com/api/vocab#singleClass",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "",
+                            "description": "singleClass changed.",
                             "statusCode": 200,
-                            "title": "singleClass changed."
+                            "title": ""
                         }
                     ],
                     "returns": "null",
@@ -229,9 +206,9 @@ doc = {
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "",
+                            "description": "singleClass deleted.",
                             "statusCode": 200,
-                            "title": "singleClass deleted."
+                            "title": ""
                         }
                     ],
                     "returns": "null",
@@ -240,16 +217,16 @@ doc = {
                 },
                 {
                     "@type": "http://schema.org/AddAction",
-                    "expects": "vocab:singleClass",
+                    "expects": "http://hydrus.com/api/vocab#singleClass",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "",
+                            "description": "singleClass successfully added.",
                             "statusCode": 201,
-                            "title": "singleClass successfully added."
+                            "title": ""
                         }
                     ],
                     "returns": "null",
@@ -265,12 +242,12 @@ doc = {
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "",
+                            "description": "singleClass returned.",
                             "statusCode": 200,
-                            "title": "singleClass returned."
+                            "title": ""
                         }
                     ],
-                    "returns": "vocab:singleClass",
+                    "returns": "http://hydrus.com/api/vocab#singleClass",
                     "returnsHeader": [],
                     "title": "GetClass"
                 }
@@ -280,44 +257,80 @@ doc = {
                     "@type": "SupportedProperty",
                     "property": "http://props.hydrus.com/prop1",
                     "readable": "false",
-                    "required": "true",
+                    "required": "false",
                     "title": "Prop1",
                     "writeable": "true"
                 },
                 {
                     "@type": "SupportedProperty",
                     "property": "http://props.hydrus.com/prop1",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "false",
                     "title": "Prop2",
-                    "writeable": "false"
+                    "writeable": "true"
                 },
                 {
                     "@type": "SupportedProperty",
                     "property": {
-                        "@id": "vocab:singleClass/dummyProp",
+                        "@id": "http://hydrus.com/api/vocab#singleClass/dummyProp",
                         "@type": "hydra:Link",
                         "description": "",
-                        "domain": "vocab:singleClass",
-                        "range": "vocab:dummyClass",
+                        "domain": "http://hydrus.com/api/vocab#singleClass",
+                        "range": "http://hydrus.com/api/vocab#dummyClass",
                         "supportedOperation": [],
                         "title": "dummyProp"
                     },
-                    "readable": "true",
+                    "readable": "false",
                     "required": "false",
                     "title": "dummyProp",
                     "writeable": "true"
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "vocab:anotherSingleClass",
-                    "readable": "true",
+                    "property": "http://hydrus.com/api/vocab#anotherSingleClass",
+                    "readable": "false",
                     "required": "false",
                     "title": "singleClassProp",
                     "writeable": "true"
                 }
             ],
             "title": "singleClass"
+        },
+        {
+            "@id": "http://hydrus.com/api/vocab#anotherSingleClass",
+            "@type": "hydra:Class",
+            "description": "An another non collection class",
+            "supportedOperation": [
+                {
+                    "@type": "http://schema.org/FindAction",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "anotherSingleClass returned.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://hydrus.com/api/vocab#anotherSingleClass",
+                    "returnsHeader": [],
+                    "title": "GetClass"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://props.hydrus.com/prop1",
+                    "readable": "false",
+                    "required": "false",
+                    "title": "Prop1",
+                    "writeable": "true"
+                }
+            ],
+            "title": "anotherSingleClass"
         },
         {
             "@id": "http://www.w3.org/ns/hydra/core#Resource",
@@ -345,46 +358,88 @@ doc = {
             "title": "Collection"
         },
         {
-            "@id": "vocab:dummyClassCollection",
-            "@type": "hydra:Class",
-            "description": "A collection of dummyclass",
+            "@id": "http://hydrus.com/api/vocab#Extraclasses",
+            "@type": "Collection",
+            "description": "This collection comprises of instances of ExtraClass",
+            "manages": {
+                "object": "http://hydrus.com/api/vocab#extraClass",
+                "property": "rdf:type"
+            },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "_:dummyclass_collection_retrieve",
+                    "@id": "_:Extraclasses_retrieve",
                     "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all dummyClass entities",
+                    "description": "Retrieves all the members of Extraclasses",
                     "expects": "null",
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "vocab:dummyClassCollection",
+                    "returns": "http://hydrus.com/api/vocab#extraClass",
                     "returnsHeader": []
                 },
                 {
-                    "@id": "_:dummyclass_create",
+                    "@id": "_:Extraclasses_create",
                     "@type": "http://schema.org/AddAction",
-                    "description": "Create new dummyClass entity",
-                    "expects": "vocab:dummyClass",
+                    "description": "Create new member in Extraclasses",
+                    "expects": "http://hydrus.com/api/vocab#extraClass",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "If the dummyClass entity was createdsuccessfully.",
+                            "description": "A new member in Extraclasses created",
                             "statusCode": 201,
                             "title": ""
                         }
                     ],
-                    "returns": "vocab:dummyClass",
+                    "returns": "http://hydrus.com/api/vocab#extraClass",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:Extraclasses_update",
+                    "@type": "http://schema.org/UpdateAction",
+                    "description": "Update member of  Extraclasses ",
+                    "expects": "http://hydrus.com/api/vocab#extraClass",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If the entity was updatedfrom Extraclasses.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://hydrus.com/api/vocab#extraClass",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:Extraclasses_delete",
+                    "@type": "http://schema.org/DeleteAction",
+                    "description": "Delete member of Extraclasses ",
+                    "expects": "http://hydrus.com/api/vocab#extraClass",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If entity was deletedsuccessfully from Extraclasses.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://hydrus.com/api/vocab#extraClass",
                     "returnsHeader": []
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "description": "The dummyclass",
+                    "description": "The members of Extraclasses",
                     "property": "http://www.w3.org/ns/hydra/core#member",
                     "readable": "false",
                     "required": "false",
@@ -392,49 +447,91 @@ doc = {
                     "writeable": "false"
                 }
             ],
-            "title": "dummyClassCollection"
+            "title": "Extraclasses"
         },
         {
-            "@id": "vocab:extraClassCollection",
-            "@type": "hydra:Class",
-            "description": "A collection of extraclass",
+            "@id": "http://hydrus.com/api/vocab#dummyclasses",
+            "@type": "Collection",
+            "description": "This collection comprises of instances of dummyClass",
+            "manages": {
+                "object": "http://hydrus.com/api/vocab#dummyClass",
+                "property": "rdf:type"
+            },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "_:extraclass_collection_retrieve",
+                    "@id": "_:dummyclasses_retrieve",
                     "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all extraClass entities",
+                    "description": "Retrieves all the members of dummyclasses",
                     "expects": "null",
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "vocab:extraClassCollection",
+                    "returns": "http://hydrus.com/api/vocab#dummyClass",
                     "returnsHeader": []
                 },
                 {
-                    "@id": "_:extraclass_create",
+                    "@id": "_:dummyclasses_create",
                     "@type": "http://schema.org/AddAction",
-                    "description": "Create new extraClass entity",
-                    "expects": "vocab:extraClass",
+                    "description": "Create new member in dummyclasses",
+                    "expects": "http://hydrus.com/api/vocab#dummyClass",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "If the extraClass entity was createdsuccessfully.",
+                            "description": "A new member in dummyclasses created",
                             "statusCode": 201,
                             "title": ""
                         }
                     ],
-                    "returns": "vocab:extraClass",
+                    "returns": "http://hydrus.com/api/vocab#dummyClass",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:dummyclasses_update",
+                    "@type": "http://schema.org/UpdateAction",
+                    "description": "Update member of  dummyclasses ",
+                    "expects": "http://hydrus.com/api/vocab#dummyClass",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If the entity was updatedfrom dummyclasses.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://hydrus.com/api/vocab#dummyClass",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:dummyclasses_delete",
+                    "@type": "http://schema.org/DeleteAction",
+                    "description": "Delete member of dummyclasses ",
+                    "expects": "http://hydrus.com/api/vocab#dummyClass",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If entity was deletedsuccessfully from dummyclasses.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://hydrus.com/api/vocab#dummyClass",
                     "returnsHeader": []
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "description": "The extraclass",
+                    "description": "The members of dummyclasses",
                     "property": "http://www.w3.org/ns/hydra/core#member",
                     "readable": "false",
                     "required": "false",
@@ -442,16 +539,16 @@ doc = {
                     "writeable": "false"
                 }
             ],
-            "title": "extraClassCollection"
+            "title": "dummyclasses"
         },
         {
-            "@id": "vocab:EntryPoint",
+            "@id": "http://hydrus.com/api#EntryPoint",
             "@type": "hydra:Class",
             "description": "The main entry point or homepage of the API.",
             "supportedOperation": [
                 {
                     "@id": "_:entry_point",
-                    "@type": "vocab:EntryPoint",
+                    "@type": "http://hydrus.com//api#EntryPoint",
                     "description": "The APIs main entry point.",
                     "expects": "null",
                     "expectsHeader": [],
@@ -463,58 +560,21 @@ doc = {
             ],
             "supportedProperty": [
                 {
-                    "hydra:description": "The anotherSingleClass Class",
-                    "hydra:title": "anothersingleclass",
-                    "property": {
-                        "@id": "vocab:EntryPoint/anotherSingleClass",
-                        "@type": "hydra:Link",
-                        "description": "An another non collection class",
-                        "domain": "vocab:EntryPoint",
-                        "label": "anotherSingleClass",
-                        "range": "vocab:anotherSingleClass",
-                        "supportedOperation": [
-                            {
-                                "@id": "getclass",
-                                "@type": "http://schema.org/FindAction",
-                                "description": "null",
-                                "expects": "null",
-                                "expectsHeader": [],
-                                "label": "GetClass",
-                                "method": "GET",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                                        "@type": "Status",
-                                        "description": "",
-                                        "statusCode": 200,
-                                        "title": "anotherSingleClass returned."
-                                    }
-                                ],
-                                "returns": "vocab:anotherSingleClass",
-                                "returnsHeader": []
-                            }
-                        ]
-                    },
-                    "readable": "true",
-                    "required": "null",
-                    "writeable": "false"
-                },
-                {
                     "hydra:description": "The singleClass Class",
                     "hydra:title": "singleclass",
                     "property": {
-                        "@id": "vocab:EntryPoint/sc_path",
+                        "@id": "http://hydrus.com/api/vocab#EntryPoint/singleClass",
                         "@type": "hydra:Link",
                         "description": "A non collection class",
-                        "domain": "vocab:EntryPoint",
+                        "domain": "http://hydrus.com/api/vocab#EntryPoint",
                         "label": "singleClass",
-                        "range": "vocab:singleClass",
+                        "range": "http://hydrus.com/api/vocab#singleClass",
                         "supportedOperation": [
                             {
                                 "@id": "updateclass",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "null",
-                                "expects": "vocab:singleClass",
+                                "expects": "http://hydrus.com/api/vocab#singleClass",
                                 "expectsHeader": [],
                                 "label": "UpdateClass",
                                 "method": "POST",
@@ -522,9 +582,9 @@ doc = {
                                     {
                                         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                                         "@type": "Status",
-                                        "description": "",
+                                        "description": "singleClass changed.",
                                         "statusCode": 200,
-                                        "title": "singleClass changed."
+                                        "title": ""
                                     }
                                 ],
                                 "returns": "null",
@@ -542,9 +602,9 @@ doc = {
                                     {
                                         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                                         "@type": "Status",
-                                        "description": "",
+                                        "description": "singleClass deleted.",
                                         "statusCode": 200,
-                                        "title": "singleClass deleted."
+                                        "title": ""
                                     }
                                 ],
                                 "returns": "null",
@@ -554,7 +614,7 @@ doc = {
                                 "@id": "addclass",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "null",
-                                "expects": "vocab:singleClass",
+                                "expects": "http://hydrus.com/api/vocab#singleClass",
                                 "expectsHeader": [],
                                 "label": "AddClass",
                                 "method": "PUT",
@@ -562,9 +622,9 @@ doc = {
                                     {
                                         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                                         "@type": "Status",
-                                        "description": "",
+                                        "description": "singleClass successfully added.",
                                         "statusCode": 201,
-                                        "title": "singleClass successfully added."
+                                        "title": ""
                                     }
                                 ],
                                 "returns": "null",
@@ -582,12 +642,12 @@ doc = {
                                     {
                                         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                                         "@type": "Status",
-                                        "description": "",
+                                        "description": "singleClass returned.",
                                         "statusCode": 200,
-                                        "title": "singleClass returned."
+                                        "title": ""
                                     }
                                 ],
-                                "returns": "vocab:singleClass",
+                                "returns": "http://hydrus.com/api/vocab#singleClass",
                                 "returnsHeader": []
                             }
                         ]
@@ -597,44 +657,34 @@ doc = {
                     "writeable": "false"
                 },
                 {
-                    "hydra:description": "The dummyClassCollection collection",
-                    "hydra:title": "dummyclasscollection",
+                    "hydra:description": "The anotherSingleClass Class",
+                    "hydra:title": "anothersingleclass",
                     "property": {
-                        "@id": "vocab:EntryPoint/DcTest",
+                        "@id": "http://hydrus.com/api/vocab#EntryPoint/anotherSingleClass",
                         "@type": "hydra:Link",
-                        "description": "The dummyClassCollection collection",
-                        "domain": "vocab:EntryPoint",
-                        "label": "dummyClassCollection",
-                        "range": "vocab:dummyClassCollection",
+                        "description": "An another non collection class",
+                        "domain": "http://hydrus.com/api/vocab#EntryPoint",
+                        "label": "anotherSingleClass",
+                        "range": "http://hydrus.com/api/vocab#anotherSingleClass",
                         "supportedOperation": [
                             {
-                                "@id": "_:dummyclass_collection_retrieve",
+                                "@id": "getclass",
                                 "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all dummyClass entities",
+                                "description": "null",
                                 "expects": "null",
                                 "expectsHeader": [],
+                                "label": "GetClass",
                                 "method": "GET",
-                                "possibleStatus": [],
-                                "returns": "vocab:dummyClassCollection",
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "_:dummyclass_create",
-                                "@type": "http://schema.org/AddAction",
-                                "description": "Create new dummyClass entity",
-                                "expects": "vocab:dummyClass",
-                                "expectsHeader": [],
-                                "method": "PUT",
                                 "possibleStatus": [
                                     {
                                         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                                         "@type": "Status",
-                                        "description": "If the dummyClass entity was createdsuccessfully.",
-                                        "statusCode": 201,
+                                        "description": "anotherSingleClass returned.",
+                                        "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "vocab:dummyClass",
+                                "returns": "http://hydrus.com/api/vocab#anotherSingleClass",
                                 "returnsHeader": []
                             }
                         ]
@@ -644,44 +694,175 @@ doc = {
                     "writeable": "false"
                 },
                 {
-                    "hydra:description": "The extraClassCollection collection",
-                    "hydra:title": "extraclasscollection",
+                    "hydra:description": "The Extraclasses collection",
+                    "hydra:title": "extraclasses",
                     "property": {
-                        "@id": "vocab:EntryPoint/EcTest",
+                        "@id": "http://hydrus.com/api/vocab#EntryPoint/EcTest",
                         "@type": "hydra:Link",
-                        "description": "The extraClassCollection collection",
-                        "domain": "vocab:EntryPoint",
-                        "label": "extraClassCollection",
-                        "range": "vocab:extraClassCollection",
+                        "description": "The Extraclasses collection",
+                        "domain": "http://hydrus.com/api/vocab#EntryPoint",
+                        "label": "Extraclasses",
+                        "manages": {
+                            "object": "http://hydrus.com/api/vocab#extraClass",
+                            "property": "rdf:type"
+                        },
+                        "range": "http://hydrus.com/api/vocab#Extraclasses",
                         "supportedOperation": [
                             {
-                                "@id": "_:extraclass_collection_retrieve",
+                                "@id": "_:extraclasses_retrieve",
                                 "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all extraClass entities",
+                                "description": "Retrieves all the members of Extraclasses",
                                 "expects": "null",
                                 "expectsHeader": [],
                                 "method": "GET",
                                 "possibleStatus": [],
-                                "returns": "vocab:extraClassCollection",
+                                "returns": "http://hydrus.com/api/vocab#extraClass",
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "_:extraclass_create",
+                                "@id": "_:extraclasses_create",
                                 "@type": "http://schema.org/AddAction",
-                                "description": "Create new extraClass entity",
-                                "expects": "vocab:extraClass",
+                                "description": "Create new member in Extraclasses",
+                                "expects": "http://hydrus.com/api/vocab#extraClass",
                                 "expectsHeader": [],
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
                                         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                                         "@type": "Status",
-                                        "description": "If the extraClass entity was createdsuccessfully.",
+                                        "description": "A new member in Extraclasses created",
                                         "statusCode": 201,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "vocab:extraClass",
+                                "returns": "http://hydrus.com/api/vocab#extraClass",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:extraclasses_update",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "Update member of  Extraclasses ",
+                                "expects": "http://hydrus.com/api/vocab#extraClass",
+                                "expectsHeader": [],
+                                "method": "POST",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If the entity was updatedfrom Extraclasses.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://hydrus.com/api/vocab#extraClass",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:extraclasses_delete",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": "Delete member of Extraclasses ",
+                                "expects": "http://hydrus.com/api/vocab#extraClass",
+                                "expectsHeader": [],
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If entity was deletedsuccessfully from Extraclasses.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://hydrus.com/api/vocab#extraClass",
+                                "returnsHeader": []
+                            }
+                        ]
+                    },
+                    "readable": "true",
+                    "required": "null",
+                    "writeable": "false"
+                },
+                {
+                    "hydra:description": "The dummyclasses collection",
+                    "hydra:title": "dummyclasses",
+                    "property": {
+                        "@id": "http://hydrus.com/api/vocab#EntryPoint/DcTest",
+                        "@type": "hydra:Link",
+                        "description": "The dummyclasses collection",
+                        "domain": "http://hydrus.com/api/vocab#EntryPoint",
+                        "label": "dummyclasses",
+                        "manages": {
+                            "object": "http://hydrus.com/api/vocab#dummyClass",
+                            "property": "rdf:type"
+                        },
+                        "range": "http://hydrus.com/api/vocab#dummyclasses",
+                        "supportedOperation": [
+                            {
+                                "@id": "_:dummyclasses_retrieve",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "Retrieves all the members of dummyclasses",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "method": "GET",
+                                "possibleStatus": [],
+                                "returns": "http://hydrus.com/api/vocab#dummyClass",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:dummyclasses_create",
+                                "@type": "http://schema.org/AddAction",
+                                "description": "Create new member in dummyclasses",
+                                "expects": "http://hydrus.com/api/vocab#dummyClass",
+                                "expectsHeader": [],
+                                "method": "PUT",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "A new member in dummyclasses created",
+                                        "statusCode": 201,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://hydrus.com/api/vocab#dummyClass",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:dummyclasses_update",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "Update member of  dummyclasses ",
+                                "expects": "http://hydrus.com/api/vocab#dummyClass",
+                                "expectsHeader": [],
+                                "method": "POST",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If the entity was updatedfrom dummyclasses.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://hydrus.com/api/vocab#dummyClass",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:dummyclasses_delete",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": "Delete member of dummyclasses ",
+                                "expects": "http://hydrus.com/api/vocab#dummyClass",
+                                "expectsHeader": [],
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If entity was deletedsuccessfully from dummyclasses.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://hydrus.com/api/vocab#dummyClass",
                                 "returnsHeader": []
                             }
                         ]

--- a/hydrus/samples/hydra_doc_sample.py
+++ b/hydrus/samples/hydra_doc_sample.py
@@ -9,13 +9,23 @@ doc = {
             "@id": "rdfs:domain",
             "@type": "@id"
         },
+        "entrypoint": {
+            "@id": "hydra:entrypoint",
+            "@type": "@id"
+        },
         "expects": {
             "@id": "hydra:expects",
             "@type": "@id"
         },
+        "expectsHeader": "hydra:expectsHeader",
         "hydra": "http://www.w3.org/ns/hydra/core#",
         "label": "rdfs:label",
+        "manages": "hydra:manages",
         "method": "hydra:method",
+        "object": {
+            "@id": "hydra:object",
+            "@type": "@id"
+        },
         "possibleStatus": "hydra:possibleStatus",
         "property": {
             "@id": "hydra:property",
@@ -33,49 +43,167 @@ doc = {
             "@id": "hydra:returns",
             "@type": "@id"
         },
+        "returnsHeader": "hydra:returnsHeader",
+        "search": "hydra:search",
         "statusCode": "hydra:statusCode",
         "subClassOf": {
             "@id": "rdfs:subClassOf",
+            "@type": "@id"
+        },
+        "subject": {
+            "@id": "hydra:subject",
             "@type": "@id"
         },
         "supportedClass": "hydra:supportedClass",
         "supportedOperation": "hydra:supportedOperation",
         "supportedProperty": "hydra:supportedProperty",
         "title": "hydra:title",
-        "vocab": "http://localhost:8080/api/vocab#",
-        "writeable": "hydra:writeable",
-        "expectsHeader": "hydra:expectsHeader",
-        "returnsHeader": "hydra:returnsHeader",
-        "manages": "hydra:manages"
+        "writeable": "hydra:writeable"
     },
     "@id": "http://localhost:8080/api/vocab",
     "@type": "ApiDocumentation",
     "description": "API Documentation for the server side system",
+    "entrypoint": "http://localhost:8080/api",
     "possibleStatus": [],
     "supportedClass": [
         {
-            "@id": "vocab:State",
+            "@id": "http://localhost:8080/api/vocab#Drone",
+            "@type": "hydra:Class",
+            "description": "Class for a drone",
+            "supportedOperation": [
+                {
+                    "@type": "http://schema.org/UpdateAction",
+                    "expects": "http://localhost:8080/api/vocab#Drone",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Drone updated",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "null",
+                    "returnsHeader": [],
+                    "title": "SubmitDrone"
+                },
+                {
+                    "@type": "http://schema.org/AddAction",
+                    "expects": "http://localhost:8080/api/vocab#Drone",
+                    "expectsHeader": [],
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Drone added",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "null",
+                    "returnsHeader": [],
+                    "title": "CreateDrone"
+                },
+                {
+                    "@type": "http://schema.org/FindAction",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Drone not found",
+                            "statusCode": 404,
+                            "title": ""
+                        },
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Drone Returned",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#Drone",
+                    "returnsHeader": [],
+                    "title": "GetDrone"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://localhost:8080/api/vocab#State",
+                    "readable": "false",
+                    "required": "true",
+                    "title": "DroneState",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/name",
+                    "readable": "false",
+                    "required": "true",
+                    "title": "name",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/model",
+                    "readable": "false",
+                    "required": "true",
+                    "title": "model",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://auto.schema.org/speed",
+                    "readable": "false",
+                    "required": "true",
+                    "title": "MaxSpeed",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/device",
+                    "readable": "false",
+                    "required": "true",
+                    "title": "Sensor",
+                    "writeable": "false"
+                }
+            ],
+            "title": "Drone"
+        },
+        {
+            "@id": "http://localhost:8080/api/vocab#State",
             "@type": "hydra:Class",
             "description": "Class for drone state objects",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/FindAction",
                     "expects": "null",
+                    "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "title": "State not found",
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "State not found",
                             "statusCode": 404,
-                            "description": ""
+                            "title": ""
                         },
                         {
-                            "title": "State Returned",
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "State Returned",
                             "statusCode": 200,
-                            "description": ""
+                            "title": ""
                         }
                     ],
                     "returns": "vocab:State",
-                    "expectsHeader": [],
                     "returnsHeader": [],
                     "title": "GetState"
                 }
@@ -84,306 +212,117 @@ doc = {
                 {
                     "@type": "SupportedProperty",
                     "property": "http://auto.schema.org/speed",
-                    "readable": "ture",
+                    "readable": "false",
                     "required": "true",
                     "title": "Speed",
-                    "writeable": "true"
+                    "writeable": "false"
                 },
                 {
                     "@type": "SupportedProperty",
                     "property": "http://schema.org/geo",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "true",
                     "title": "Position",
-                    "writeable": "true"
+                    "writeable": "false"
                 },
                 {
                     "@type": "SupportedProperty",
                     "property": "http://schema.org/Property",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "true",
                     "title": "Direction",
-                    "writeable": "true"
+                    "writeable": "false"
                 },
                 {
                     "@type": "SupportedProperty",
                     "property": "http://schema.org/fuelCapacity",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "true",
                     "title": "Battery",
-                    "writeable": "true"
+                    "writeable": "false"
                 },
                 {
                     "@type": "SupportedProperty",
                     "property": "https://schema.org/status",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "true",
                     "title": "SensorStatus",
-                    "writeable": "true"
+                    "writeable": "false"
                 },
                 {
                     "@type": "SupportedProperty",
                     "property": "http://schema.org/identifier",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "true",
                     "title": "DroneID",
-                    "writeable": "true"
+                    "writeable": "false"
                 }
             ],
             "title": "State"
         },
         {
-            "@id": "vocab:Command",
-            "@type": "hydra:Class",
-            "description": "Class for drone commands",
-            "supportedOperation": [
-                {
-                    "@type": "http://schema.org/FindAction",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "title": "Command not found",
-                            "statusCode": 404,
-                            "description": ""
-                        },
-                        {
-                            "title": "Command Returned",
-                            "statusCode": 200,
-                            "description": ""
-                        }
-                    ],
-                    "returns": "vocab:Command",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "title": "GetCommand"
-                },
-                {
-                    "@type": "http://schema.org/AddAction",
-                    "expects": "vocab:Command",
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "title": "Command added",
-                            "statusCode": 201,
-                            "description": ""
-                        }
-                    ],
-                    "returns": "null",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "title": "AddCommand"
-                },
-                {
-                    "@type": "http://schema.org/DeleteAction",
-                    "expects": "null",
-                    "method": "DELETE",
-                    "possibleStatus": [
-                        {
-                            "title": "Command deleted",
-                            "statusCode": 201,
-                            "description": ""
-                        }
-                    ],
-                    "returns": "null",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "title": "DeleteCommand"
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/identifier",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "DroneID",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "vocab:State",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "State",
-                    "writeable": "true"
-                }
-            ],
-            "title": "Command"
-        },
-        {
-            "@id": "vocab:Message",
-            "@type": "hydra:Class",
-            "description": "Class for messages received by the GUI interface",
-            "supportedOperation": [
-                {
-                    "@type": "http://schema.org/FindAction",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "title": "Message not found",
-                            "statusCode": 404,
-                            "description": ""
-                        },
-                        {
-                            "title": "Message returned",
-                            "statusCode": 200,
-                            "description": ""
-                        }
-                    ],
-                    "returns": "vocab:Message",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "title": "GetMessage"
-                },
-                {
-                    "@type": "http://schema.org/DeleteAction",
-                    "expects": "null",
-                    "method": "DELETE",
-                    "possibleStatus": [
-                        {
-                            "title": "Message deleted",
-                            "statusCode": 200,
-                            "description": ""
-                        }
-                    ],
-                    "returns": "null",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "title": "DeleteMessage"
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/Text",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "MessageString",
-                    "writeable": "true"
-                }
-            ],
-            "title": "Message"
-        },
-        {
-            "@id": "vocab:Area",
-            "@type": "hydra:Class",
-            "description": "Class for Area of Interest of the server",
-            "supportedOperation": [
-                {
-                    "@type": "http://schema.org/UpdateAction",
-                    "expects": "vocab:Area",
-                    "method": "POST",
-                    "possibleStatus": [
-                        {
-                            "title": "Area of interest changed",
-                            "statusCode": 200,
-                            "description": ""
-                        }
-                    ],
-                    "returns": "null",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "title": "UpdateArea"
-                },
-                {
-                    "@type": "http://schema.org/FindAction",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "title": "Area of interest not found",
-                            "statusCode": 404,
-                            "description": ""
-                        },
-                        {
-                            "title": "Area of interest returned",
-                            "statusCode": 200,
-                            "description": ""
-                        }
-                    ],
-                    "returns": "vocab:Area",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "title": "GetArea"
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/geo",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "TopLeft",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/geo",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "BottomRight",
-                    "writeable": "true"
-                }
-            ],
-            "title": "Area"
-        },
-        {
-            "@id": "vocab:Datastream",
+            "@id": "http://localhost:8080/api/vocab#Datastream",
             "@type": "hydra:Class",
             "description": "Class for a datastream entry",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/FindAction",
                     "expects": "null",
+                    "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "title": "Data not found",
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Data not found",
                             "statusCode": 404,
-                            "description": ""
+                            "title": ""
                         },
                         {
-                            "title": "Data returned",
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Data returned",
                             "statusCode": 200,
-                            "description": ""
+                            "title": ""
                         }
                     ],
-                    "returns": "vocab:Datastream",
-                    "expectsHeader": [],
+                    "returns": "http://localhost:8080/api/vocab#Datastream",
                     "returnsHeader": [],
                     "title": "ReadDatastream"
                 },
                 {
                     "@type": "http://schema.org/UpdateAction",
-                    "expects": "vocab:Datastream",
+                    "expects": "http://localhost:8080/api/vocab#Datastream",
+                    "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "title": "Data updated",
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Data updated",
                             "statusCode": 200,
-                            "description": ""
+                            "title": ""
                         }
                     ],
                     "returns": "null",
-                    "expectsHeader": [],
                     "returnsHeader": [],
                     "title": "UpdateDatastream"
                 },
                 {
                     "@type": "http://schema.org/DeleteAction",
                     "expects": "null",
+                    "expectsHeader": [],
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "title": "Data deleted",
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Data deleted",
                             "statusCode": 200,
-                            "description": ""
+                            "title": ""
                         }
                     ],
                     "returns": "null",
-                    "expectsHeader": [],
                     "returnsHeader": [],
                     "title": "DeleteDatastream"
                 }
@@ -392,201 +331,75 @@ doc = {
                 {
                     "@type": "SupportedProperty",
                     "property": "http://schema.org/QuantitativeValue",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "true",
                     "title": "Temperature",
-                    "writeable": "true"
+                    "writeable": "false"
                 },
                 {
                     "@type": "SupportedProperty",
                     "property": "http://schema.org/identifier",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "true",
                     "title": "DroneID",
-                    "writeable": "true"
+                    "writeable": "false"
                 },
                 {
                     "@type": "SupportedProperty",
                     "property": "http://schema.org/geo",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "true",
                     "title": "Position",
-                    "writeable": "true"
+                    "writeable": "false"
                 }
             ],
             "title": "Datastream"
         },
         {
-            "@id": "vocab:Drone",
-            "@type": "hydra:Class",
-            "description": "Class for a drone",
-            "supportedOperation": [
-                {
-                    "@type": "http://schema.org/UpdateAction",
-                    "expects": "vocab:Drone",
-                    "method": "POST",
-                    "possibleStatus": [
-                        {
-                            "title": "Drone updated",
-                            "statusCode": 200,
-                            "description": ""
-                        }
-                    ],
-                    "returns": "null",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "title": "SubmitDrone"
-                },
-                {
-                    "@type": "http://schema.org/AddAction",
-                    "expects": "vocab:Drone",
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "title": "Drone added",
-                            "statusCode": 200,
-                            "description": ""
-                        }
-                    ],
-                    "returns": "null",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "title": "CreateDrone"
-                },
-                {
-                    "@type": "http://schema.org/FindAction",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "title": "Drone not found",
-                            "statusCode": 404,
-                            "description": ""
-                        },
-                        {
-                            "title": "Drone Returned",
-                            "statusCode": 200,
-                            "description": ""
-                        }
-                    ],
-                    "returns": "vocab:Drone",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "title": "GetDrone"
-                },
-                {
-                    "@type": "http://schema.org/DeleteAction",
-                    "expects": "null",
-                    "method": "DELETE",
-                    "possibleStatus": [
-                        {
-                            "title": "Drone not found",
-                            "statusCode": 404,
-                            "description": ""
-                        },
-                        {
-                            "title": "Drone successfully deleted",
-                            "statusCode": 200,
-                            "description": ""
-                        }
-                    ],
-                    "returns": "null",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "title": "DeleteDrone"
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "property": {
-                        "@id": "vocab:Drone/DroneState",
-                        "@type": "hydra:Link",
-                        "description": "",
-                        "domain": "vocab:Drone",
-                        "range": "vocab:State",
-                        "supportedOperation": [],
-                        "title": "Drone State"
-                    },
-                    "readable": "true",
-                    "required": "false",
-                    "title": "DroneState",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/name",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "name",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/model",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "model",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://auto.schema.org/speed",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "MaxSpeed",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/device",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "Sensor",
-                    "writeable": "true"
-                }
-            ],
-            "title": "Drone"
-        },
-        {
-            "@id": "vocab:LogEntry",
+            "@id": "http://localhost:8080/api/vocab#LogEntry",
             "@type": "hydra:Class",
             "description": "Class for a log entry",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/FindAction",
                     "expects": "null",
+                    "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "title": "Log entry not found",
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Log entry not found",
                             "statusCode": 404,
-                            "description": ""
+                            "title": ""
                         },
                         {
-                            "title": "Log entry returned",
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Log entry returned",
                             "statusCode": 200,
-                            "description": ""
+                            "title": ""
                         }
                     ],
-                    "returns": "vocab:LogEntry",
-                    "expectsHeader": [],
+                    "returns": "http://localhost:8080/api/vocab#LogEntry",
                     "returnsHeader": [],
                     "title": "GetLog"
                 },
                 {
                     "@type": "http://schema.org/AddAction",
-                    "expects": "vocab:LogEntry",
+                    "expects": "http://localhost:8080/api/vocab#LogEntry",
+                    "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "title": "Log entry created",
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Log entry created",
                             "statusCode": 201,
-                            "description": ""
+                            "title": ""
                         }
                     ],
                     "returns": "null",
-                    "expectsHeader": [],
                     "returnsHeader": [],
                     "title": "AddLog"
                 }
@@ -626,7 +439,7 @@ doc = {
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "vocab:State",
+                    "property": "http://localhost:8080/api/vocab#State",
                     "readable": "false",
                     "required": "false",
                     "title": "State",
@@ -634,7 +447,7 @@ doc = {
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "vocab:Datastream",
+                    "property": "http://localhost:8080/api/vocab#Datastream",
                     "readable": "false",
                     "required": "false",
                     "title": "Data",
@@ -642,7 +455,7 @@ doc = {
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "vocab:Command",
+                    "property": "http://localhost:8080/api/vocab#Command",
                     "readable": "false",
                     "required": "false",
                     "title": "Command",
@@ -650,6 +463,223 @@ doc = {
                 }
             ],
             "title": "LogEntry"
+        },
+        {
+            "@id": "http://localhost:8080/api/vocab#Area",
+            "@type": "hydra:Class",
+            "description": "Class for Area of Interest of the server",
+            "supportedOperation": [
+                {
+                    "@type": "http://schema.org/UpdateAction",
+                    "expects": "http://localhost:8080/api/vocab#Area",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Area of interest changed",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "null",
+                    "returnsHeader": [],
+                    "title": "UpdateArea"
+                },
+                {
+                    "@type": "http://schema.org/FindAction",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Area of interest not found",
+                            "statusCode": 200,
+                            "title": ""
+                        },
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Area of interest returned",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#Area",
+                    "returnsHeader": [],
+                    "title": "GetArea"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/geo",
+                    "readable": "false",
+                    "required": "true",
+                    "title": "TopLeft",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/geo",
+                    "readable": "false",
+                    "required": "true",
+                    "title": "BottomRight",
+                    "writeable": "false"
+                }
+            ],
+            "title": "Area"
+        },
+        {
+            "@id": "http://localhost:8080/api/vocab#Command",
+            "@type": "hydra:Class",
+            "description": "Class for drone commands",
+            "supportedOperation": [
+                {
+                    "@type": "http://schema.org/FindAction",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Command not found",
+                            "statusCode": 404,
+                            "title": ""
+                        },
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Command Returned",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#Command",
+                    "returnsHeader": [],
+                    "title": "GetCommand"
+                },
+                {
+                    "@type": "http://schema.org/AddAction",
+                    "expects": "http://localhost:8080/api/vocab#Command",
+                    "expectsHeader": [],
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Command added",
+                            "statusCode": 201,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "null",
+                    "returnsHeader": [],
+                    "title": "AddCommand"
+                },
+                {
+                    "@type": "http://schema.org/DeleteAction",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Command deleted",
+                            "statusCode": 201,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "null",
+                    "returnsHeader": [],
+                    "title": "DeleteCommand"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/identifier",
+                    "readable": "false",
+                    "required": "true",
+                    "title": "DroneID",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://localhost:8080/api/vocab#State",
+                    "readable": "false",
+                    "required": "true",
+                    "title": "State",
+                    "writeable": "false"
+                }
+            ],
+            "title": "Command"
+        },
+        {
+            "@id": "http://localhost:8080/api/vocab#Message",
+            "@type": "hydra:Class",
+            "description": "Message",
+            "supportedOperation": [
+                {
+                    "@type": "http://schema.org/FindAction",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Message not found",
+                            "statusCode": 200,
+                            "title": ""
+                        },
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Message returned",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#Message",
+                    "returnsHeader": [],
+                    "title": "GetMessage"
+                },
+                {
+                    "@type": "http://schema.org/DeleteAction",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "Message deleted",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "null",
+                    "returnsHeader": [],
+                    "title": "DeleteMessage"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/Text",
+                    "readable": "false",
+                    "required": "true",
+                    "title": "MessageString",
+                    "writeable": "false"
+                }
+            ],
+            "title": "Message"
         },
         {
             "@id": "http://www.w3.org/ns/hydra/core#Resource",
@@ -668,371 +698,825 @@ doc = {
                 {
                     "@type": "SupportedProperty",
                     "property": "http://www.w3.org/ns/hydra/core#member",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "null",
                     "title": "members",
-                    "writeable": "true"
+                    "writeable": "false"
                 }
             ],
             "title": "Collection"
         },
         {
-            "@id": "vocab:CommandCollection",
-            "@type": "hydra:Class",
-            "description": "A collection of command",
+            "@id": "http://localhost:8080/api/vocab#MessageCollection",
+            "@type": "Collection",
+            "description": "A collection of messages",
+            "manages": {
+                "object": "http://localhost:8080/api/vocab#Message",
+                "property": "rdfs:type"
+            },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "_:command_collection_retrieve",
+                    "@id": "_:MessageCollection_retrieve",
                     "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all Command entities",
+                    "description": "Retrieves all the members of MessageCollection",
                     "expects": "null",
-                    "method": "GET",
-                    "returns": "vocab:CommandCollection",
                     "expectsHeader": [],
-                    "returnsHeader": [],
-                    "possibleStatus": []
+                    "method": "GET",
+                    "possibleStatus": [],
+                    "returns": "http://localhost:8080/api/vocab#Message",
+                    "returnsHeader": []
                 },
                 {
-                    "@id": "_:command_create",
+                    "@id": "_:MessageCollection_create",
                     "@type": "http://schema.org/AddAction",
-                    "description": "Create new Command entity",
-                    "expects": "vocab:Command",
-                    "method": "PUT",
-                    "returns": "vocab:Command",
+                    "description": "Create new member in MessageCollection",
+                    "expects": "http://localhost:8080/api/vocab#Message",
                     "expectsHeader": [],
-                    "returnsHeader": [],
+                    "method": "PUT",
                     "possibleStatus": [
                         {
-                            "title": "If the Command entity was created successfully.",
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "A new member in MessageCollection created",
                             "statusCode": 201,
-                            "description": ""
+                            "title": ""
                         }
-                    ]
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#Message",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:MessageCollection_update",
+                    "@type": "http://schema.org/UpdateAction",
+                    "description": "Update member of  MessageCollection ",
+                    "expects": "http://localhost:8080/api/vocab#Message",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If the entity was updatedfrom MessageCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#Message",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:MessageCollection_delete",
+                    "@type": "http://schema.org/DeleteAction",
+                    "description": "Delete member of MessageCollection ",
+                    "expects": "http://localhost:8080/api/vocab#Message",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If entity was deletedsuccessfully from MessageCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#Message",
+                    "returnsHeader": []
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "description": "The command",
+                    "description": "The members of MessageCollection",
                     "property": "http://www.w3.org/ns/hydra/core#member",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "false",
                     "title": "members",
-                    "writeable": "true"
-                }
-            ],
-            "title": "CommandCollection"
-        },
-        {
-            "@id": "vocab:StateCollection",
-            "@type": "hydra:Class",
-            "description": "A collection of state",
-            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
-            "supportedOperation": [
-                {
-                    "@id": "_:state_collection_retrieve",
-                    "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all State entities",
-                    "expects": "null",
-                    "method": "GET",
-                    "returns": "vocab:StateCollection",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "possibleStatus": []
-                },
-                {
-                    "@id": "_:state_create",
-                    "@type": "http://schema.org/AddAction",
-                    "description": "Create new State entity",
-                    "expects": "vocab:State",
-                    "method": "PUT",
-                    "returns": "vocab:State",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "possibleStatus": [
-                        {
-                            "title": "If the State entity was created successfully.",
-                            "statusCode": 201,
-                            "description": ""
-                        }
-                    ]
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "description": "The state",
-                    "property": "http://www.w3.org/ns/hydra/core#member",
-                    "readable": "true",
-                    "required": "false",
-                    "title": "members",
-                    "writeable": "true"
-                }
-            ],
-            "title": "StateCollection"
-        },
-        {
-            "@id": "vocab:MessageCollection",
-            "@type": "hydra:Class",
-            "description": "A collection of message",
-            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
-            "supportedOperation": [
-                {
-                    "@id": "_:message_collection_retrieve",
-                    "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all Message entities",
-                    "expects": "null",
-                    "method": "GET",
-                    "returns": "vocab:MessageCollection",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "possibleStatus": []
-                },
-                {
-                    "@id": "_:message_create",
-                    "@type": "http://schema.org/AddAction",
-                    "description": "Create new Message entity",
-                    "expects": "vocab:Message",
-                    "method": "PUT",
-                    "returns": "vocab:Message",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "possibleStatus": [
-                        {
-                            "title": "If the Message entity was created successfully.",
-                            "statusCode": 201,
-                            "description": ""
-                        }
-                    ]
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "description": "The message",
-                    "property": "http://www.w3.org/ns/hydra/core#member",
-                    "readable": "true",
-                    "required": "false",
-                    "title": "members",
-                    "writeable": "true"
+                    "writeable": "false"
                 }
             ],
             "title": "MessageCollection"
         },
         {
-            "@id": "vocab:DroneCollection",
-            "@type": "hydra:Class",
-            "description": "A collection of drone",
+            "@id": "http://localhost:8080/api/vocab#StateCollection",
+            "@type": "Collection",
+            "description": "A collection of states",
+            "manages": {
+                "object": "http://localhost:8080/api/vocab#State",
+                "property": "rdfs:type"
+            },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "_:drone_collection_retrieve",
+                    "@id": "_:StateCollection_retrieve",
                     "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all Drone entities",
+                    "description": "Retrieves all the members of StateCollection",
                     "expects": "null",
-                    "method": "GET",
-                    "returns": "vocab:DroneCollection",
                     "expectsHeader": [],
-                    "returnsHeader": [],
-                    "possibleStatus": []
+                    "method": "GET",
+                    "possibleStatus": [],
+                    "returns": "http://localhost:8080/api/vocab#State",
+                    "returnsHeader": []
                 },
                 {
-                    "@id": "_:drone_create",
+                    "@id": "_:StateCollection_create",
                     "@type": "http://schema.org/AddAction",
-                    "description": "Create new Drone entity",
-                    "expects": "vocab:Drone",
-                    "method": "PUT",
-                    "returns": "vocab:Drone",
+                    "description": "Create new member in StateCollection",
+                    "expects": "http://localhost:8080/api/vocab#State",
                     "expectsHeader": [],
-                    "returnsHeader": [],
+                    "method": "PUT",
                     "possibleStatus": [
                         {
-                            "title": "If the Drone entity was created successfully.",
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "A new member in StateCollection created",
                             "statusCode": 201,
-                            "description": ""
+                            "title": ""
                         }
-                    ]
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#State",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:StateCollection_update",
+                    "@type": "http://schema.org/UpdateAction",
+                    "description": "Update member of  StateCollection ",
+                    "expects": "http://localhost:8080/api/vocab#State",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If the entity was updatedfrom StateCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#State",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:StateCollection_delete",
+                    "@type": "http://schema.org/DeleteAction",
+                    "description": "Delete member of StateCollection ",
+                    "expects": "http://localhost:8080/api/vocab#State",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If entity was deletedsuccessfully from StateCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#State",
+                    "returnsHeader": []
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "description": "The drone",
+                    "description": "The members of StateCollection",
                     "property": "http://www.w3.org/ns/hydra/core#member",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "false",
                     "title": "members",
-                    "writeable": "true"
+                    "writeable": "false"
                 }
             ],
-            "title": "DroneCollection"
+            "title": "StateCollection"
         },
         {
-            "@id": "vocab:LogEntryCollection",
-            "@type": "hydra:Class",
-            "description": "A collection of logentry",
-            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
-            "supportedOperation": [
-                {
-                    "@id": "_:logentry_collection_retrieve",
-                    "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all LogEntry entities",
-                    "expects": "null",
-                    "method": "GET",
-                    "returns": "vocab:LogEntryCollection",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "possibleStatus": []
-                },
-                {
-                    "@id": "_:logentry_create",
-                    "@type": "http://schema.org/AddAction",
-                    "description": "Create new LogEntry entity",
-                    "expects": "vocab:LogEntry",
-                    "method": "PUT",
-                    "returns": "vocab:LogEntry",
-                    "expectsHeader": [],
-                    "returnsHeader": [],
-                    "possibleStatus": [
-                        {
-                            "title": "If the LogEntry entity was created successfully.",
-                            "statusCode": 201,
-                            "description": ""
-                        }
-                    ]
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "description": "The logentry",
-                    "property": "http://www.w3.org/ns/hydra/core#member",
-                    "readable": "true",
-                    "required": "false",
-                    "title": "members",
-                    "writeable": "true"
-                }
-            ],
-            "title": "LogEntryCollection"
-        },
-        {
-            "@id": "vocab:DatastreamCollection",
-            "@type": "hydra:Class",
+            "@id": "http://localhost:8080/api/vocab#DatastreamCollection",
+            "@type": "Collection",
             "description": "A collection of datastream",
+            "manages": {
+                "object": "http://localhost:8080/api/vocab#Datastream",
+                "property": "rdfs:type"
+            },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "_:datastream_collection_retrieve",
+                    "@id": "_:DatastreamCollection_retrieve",
                     "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all Datastream entities",
+                    "description": "Retrieves all the members of DatastreamCollection",
                     "expects": "null",
-                    "method": "GET",
-                    "returns": "vocab:DatastreamCollection",
                     "expectsHeader": [],
-                    "returnsHeader": [],
-                    "possibleStatus": []
+                    "method": "GET",
+                    "possibleStatus": [],
+                    "returns": "http://localhost:8080/api/vocab#Datastream",
+                    "returnsHeader": []
                 },
                 {
-                    "@id": "_:datastream_create",
+                    "@id": "_:DatastreamCollection_create",
                     "@type": "http://schema.org/AddAction",
-                    "description": "Create new Datastream entity",
-                    "expects": "vocab:Datastream",
-                    "method": "PUT",
-                    "returns": "vocab:Datastream",
+                    "description": "Create new member in DatastreamCollection",
+                    "expects": "http://localhost:8080/api/vocab#Datastream",
                     "expectsHeader": [],
-                    "returnsHeader": [],
+                    "method": "PUT",
                     "possibleStatus": [
                         {
-                            "title": "If the Datastream entity was created successfully.",
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "A new member in DatastreamCollection created",
                             "statusCode": 201,
-                            "description": ""
+                            "title": ""
                         }
-                    ]
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#Datastream",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:DatastreamCollection_update",
+                    "@type": "http://schema.org/UpdateAction",
+                    "description": "Update member of  DatastreamCollection ",
+                    "expects": "http://localhost:8080/api/vocab#Datastream",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If the entity was updatedfrom DatastreamCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#Datastream",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:DatastreamCollection_delete",
+                    "@type": "http://schema.org/DeleteAction",
+                    "description": "Delete member of DatastreamCollection ",
+                    "expects": "http://localhost:8080/api/vocab#Datastream",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If entity was deletedsuccessfully from DatastreamCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#Datastream",
+                    "returnsHeader": []
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "description": "The datastream",
+                    "description": "The members of DatastreamCollection",
                     "property": "http://www.w3.org/ns/hydra/core#member",
-                    "readable": "true",
+                    "readable": "false",
                     "required": "false",
                     "title": "members",
-                    "writeable": "true"
+                    "writeable": "false"
                 }
             ],
             "title": "DatastreamCollection"
         },
         {
-            "@id": "vocab:EntryPoint",
+            "@id": "http://localhost:8080/api/vocab#LogEntryCollection",
+            "@type": "Collection",
+            "description": "A collection of logs",
+            "manages": {
+                "object": "http://localhost:8080/api/vocab#LogEntry",
+                "property": "rdfs:type"
+            },
+            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
+            "supportedOperation": [
+                {
+                    "@id": "_:LogEntryCollection_retrieve",
+                    "@type": "http://schema.org/FindAction",
+                    "description": "Retrieves all the members of LogEntryCollection",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "GET",
+                    "possibleStatus": [],
+                    "returns": "http://localhost:8080/api/vocab#LogEntry",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:LogEntryCollection_create",
+                    "@type": "http://schema.org/AddAction",
+                    "description": "Create new member in LogEntryCollection",
+                    "expects": "http://localhost:8080/api/vocab#LogEntry",
+                    "expectsHeader": [],
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "A new member in LogEntryCollection created",
+                            "statusCode": 201,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#LogEntry",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:LogEntryCollection_update",
+                    "@type": "http://schema.org/UpdateAction",
+                    "description": "Update member of  LogEntryCollection ",
+                    "expects": "http://localhost:8080/api/vocab#LogEntry",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If the entity was updatedfrom LogEntryCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#LogEntry",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:LogEntryCollection_delete",
+                    "@type": "http://schema.org/DeleteAction",
+                    "description": "Delete member of LogEntryCollection ",
+                    "expects": "http://localhost:8080/api/vocab#LogEntry",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If entity was deletedsuccessfully from LogEntryCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#LogEntry",
+                    "returnsHeader": []
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "description": "The members of LogEntryCollection",
+                    "property": "http://www.w3.org/ns/hydra/core#member",
+                    "readable": "false",
+                    "required": "false",
+                    "title": "members",
+                    "writeable": "false"
+                }
+            ],
+            "title": "LogEntryCollection"
+        },
+        {
+            "@id": "http://localhost:8080/api/vocab#CommandCollection",
+            "@type": "Collection",
+            "description": "A collection of commands",
+            "manages": {
+                "object": "http://localhost:8080/api/vocab#Command",
+                "property": "rdfs:type"
+            },
+            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
+            "supportedOperation": [
+                {
+                    "@id": "_:CommandCollection_retrieve",
+                    "@type": "http://schema.org/FindAction",
+                    "description": "Retrieves all the members of CommandCollection",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "GET",
+                    "possibleStatus": [],
+                    "returns": "http://localhost:8080/api/vocab#Command",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:CommandCollection_create",
+                    "@type": "http://schema.org/AddAction",
+                    "description": "Create new member in CommandCollection",
+                    "expects": "http://localhost:8080/api/vocab#Command",
+                    "expectsHeader": [],
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "A new member in CommandCollection created",
+                            "statusCode": 201,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#Command",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:CommandCollection_update",
+                    "@type": "http://schema.org/UpdateAction",
+                    "description": "Update member of  CommandCollection ",
+                    "expects": "http://localhost:8080/api/vocab#Command",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If the entity was updatedfrom CommandCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#Command",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:CommandCollection_delete",
+                    "@type": "http://schema.org/DeleteAction",
+                    "description": "Delete member of CommandCollection ",
+                    "expects": "http://localhost:8080/api/vocab#Command",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If entity was deletedsuccessfully from CommandCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab#Command",
+                    "returnsHeader": []
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "description": "The members of CommandCollection",
+                    "property": "http://www.w3.org/ns/hydra/core#member",
+                    "readable": "false",
+                    "required": "false",
+                    "title": "members",
+                    "writeable": "false"
+                }
+            ],
+            "title": "CommandCollection"
+        },
+        {
+            "@id": "http://localhost:8080/api#EntryPoint",
             "@type": "hydra:Class",
             "description": "The main entry point or homepage of the API.",
             "supportedOperation": [
                 {
                     "@id": "_:entry_point",
-                    "@type": "http://schema.org/FindAction",
+                    "@type": "http://localhost:8080//api#EntryPoint",
                     "description": "The APIs main entry point.",
                     "expects": "null",
-                    "method": "GET",
-                    "returns": "null",
                     "expectsHeader": [],
-                    "returnsHeader": [],
-                    "possibleStatus": "vocab:EntryPoint"
+                    "method": "GET",
+                    "possibleStatus": [],
+                    "returns": "null",
+                    "returnsHeader": []
                 }
             ],
             "supportedProperty": [
                 {
+                    "hydra:description": "The Drone Class",
+                    "hydra:title": "drone",
+                    "property": {
+                        "@id": "http://localhost:8080/api/vocab#EntryPoint/Drone",
+                        "@type": "hydra:Link",
+                        "description": "Class for a drone",
+                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "label": "Drone",
+                        "range": "http://localhost:8080/api/vocab#Drone",
+                        "supportedOperation": [
+                            {
+                                "@id": "submitdrone",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "null",
+                                "expects": "http://localhost:8080/api/vocab#Drone",
+                                "expectsHeader": [],
+                                "label": "SubmitDrone",
+                                "method": "POST",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Drone updated",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "null",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "createdrone",
+                                "@type": "http://schema.org/AddAction",
+                                "description": "null",
+                                "expects": "http://localhost:8080/api/vocab#Drone",
+                                "expectsHeader": [],
+                                "label": "CreateDrone",
+                                "method": "PUT",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Drone added",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "null",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "getdrone",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "null",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "label": "GetDrone",
+                                "method": "GET",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Drone not found",
+                                        "statusCode": 404,
+                                        "title": ""
+                                    },
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Drone Returned",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Drone",
+                                "returnsHeader": []
+                            }
+                        ]
+                    },
+                    "readable": "true",
+                    "required": "null",
+                    "writeable": "false"
+                },
+                {
+                    "hydra:description": "The State Class",
+                    "hydra:title": "state",
+                    "property": {
+                        "@id": "http://localhost:8080/api/vocab#EntryPoint/State",
+                        "@type": "hydra:Link",
+                        "description": "Class for drone state objects",
+                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "label": "State",
+                        "range": "http://localhost:8080/api/vocab#State",
+                        "supportedOperation": [
+                            {
+                                "@id": "getstate",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "null",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "label": "GetState",
+                                "method": "GET",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "State not found",
+                                        "statusCode": 404,
+                                        "title": ""
+                                    },
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "State Returned",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "vocab:State",
+                                "returnsHeader": []
+                            }
+                        ]
+                    },
+                    "readable": "true",
+                    "required": "null",
+                    "writeable": "false"
+                },
+                {
+                    "hydra:description": "The Datastream Class",
+                    "hydra:title": "datastream",
+                    "property": {
+                        "@id": "http://localhost:8080/api/vocab#EntryPoint/Datastream",
+                        "@type": "hydra:Link",
+                        "description": "Class for a datastream entry",
+                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "label": "Datastream",
+                        "range": "http://localhost:8080/api/vocab#Datastream",
+                        "supportedOperation": [
+                            {
+                                "@id": "readdatastream",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "null",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "label": "ReadDatastream",
+                                "method": "GET",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Data not found",
+                                        "statusCode": 404,
+                                        "title": ""
+                                    },
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Data returned",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Datastream",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "updatedatastream",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "null",
+                                "expects": "http://localhost:8080/api/vocab#Datastream",
+                                "expectsHeader": [],
+                                "label": "UpdateDatastream",
+                                "method": "POST",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Data updated",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "null",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "deletedatastream",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": "null",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "label": "DeleteDatastream",
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Data deleted",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "null",
+                                "returnsHeader": []
+                            }
+                        ]
+                    },
+                    "readable": "true",
+                    "required": "null",
+                    "writeable": "false"
+                },
+                {
+                    "hydra:description": "The LogEntry Class",
+                    "hydra:title": "logentry",
+                    "property": {
+                        "@id": "http://localhost:8080/api/vocab#EntryPoint/LogEntry",
+                        "@type": "hydra:Link",
+                        "description": "Class for a log entry",
+                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "label": "LogEntry",
+                        "range": "http://localhost:8080/api/vocab#LogEntry",
+                        "supportedOperation": [
+                            {
+                                "@id": "getlog",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "null",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "label": "GetLog",
+                                "method": "GET",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Log entry not found",
+                                        "statusCode": 404,
+                                        "title": ""
+                                    },
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Log entry returned",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#LogEntry",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "addlog",
+                                "@type": "http://schema.org/AddAction",
+                                "description": "null",
+                                "expects": "http://localhost:8080/api/vocab#LogEntry",
+                                "expectsHeader": [],
+                                "label": "AddLog",
+                                "method": "PUT",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Log entry created",
+                                        "statusCode": 201,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "null",
+                                "returnsHeader": []
+                            }
+                        ]
+                    },
+                    "readable": "true",
+                    "required": "null",
+                    "writeable": "false"
+                },
+                {
                     "hydra:description": "The Area Class",
                     "hydra:title": "area",
                     "property": {
-                        "@id": "vocab:EntryPoint/Area",
+                        "@id": "http://localhost:8080/api/vocab#EntryPoint/Area",
                         "@type": "hydra:Link",
                         "description": "Class for Area of Interest of the server",
-                        "domain": "vocab:EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
                         "label": "Area",
-                        "range": "vocab:Area",
+                        "range": "http://localhost:8080/api/vocab#Area",
                         "supportedOperation": [
                             {
                                 "@id": "updatearea",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "null",
-                                "expects": "vocab:Area",
+                                "expects": "http://localhost:8080/api/vocab#Area",
+                                "expectsHeader": [],
                                 "label": "UpdateArea",
                                 "method": "POST",
-                                "returns": "null",
-                                "expectsHeader": [],
-                                "returnsHeader": [],
                                 "possibleStatus": [
                                     {
-                                        "title": "Area of interest changed",
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Area of interest changed",
                                         "statusCode": 200,
-                                        "description": ""
+                                        "title": ""
                                     }
-                                ]
+                                ],
+                                "returns": "null",
+                                "returnsHeader": []
                             },
                             {
                                 "@id": "getarea",
                                 "@type": "http://schema.org/FindAction",
                                 "description": "null",
                                 "expects": "null",
+                                "expectsHeader": [],
                                 "label": "GetArea",
                                 "method": "GET",
-                                "returns": "vocab:Area",
-                                "expectsHeader": [],
-                                "returnsHeader": [],
                                 "possibleStatus": [
                                     {
-                                        "title": "Area of interest not found",
-                                        "statusCode": 404,
-                                        "description": ""
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Area of interest not found",
+                                        "statusCode": 200,
+                                        "title": ""
                                     },
                                     {
-                                        "title": "Area of interest returned",
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Area of interest returned",
                                         "statusCode": 200,
-                                        "description": ""
+                                        "title": ""
                                     }
-                                ]
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Area",
+                                "returnsHeader": []
                             }
                         ]
                     },
@@ -1041,43 +1525,82 @@ doc = {
                     "writeable": "false"
                 },
                 {
-                    "hydra:description": "The CommandCollection collection",
-                    "hydra:title": "commandcollection",
+                    "hydra:description": "The Command Class",
+                    "hydra:title": "command",
                     "property": {
-                        "@id": "vocab:EntryPoint/CommandCollection",
+                        "@id": "http://localhost:8080/api/vocab#EntryPoint/Command",
                         "@type": "hydra:Link",
-                        "description": "The CommandCollection collection",
-                        "domain": "vocab:EntryPoint",
-                        "label": "CommandCollection",
-                        "range": "vocab:CommandCollection",
+                        "description": "Class for drone commands",
+                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "label": "Command",
+                        "range": "http://localhost:8080/api/vocab#Command",
                         "supportedOperation": [
                             {
-                                "@id": "_:command_collection_retrieve",
+                                "@id": "getcommand",
                                 "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all Command entities",
+                                "description": "null",
                                 "expects": "null",
+                                "expectsHeader": [],
+                                "label": "GetCommand",
                                 "method": "GET",
-                                "returns": "vocab:CommandCollection",
-                                "expectsHeader": [],
-                                "returnsHeader": [],
-                                "possibleStatus": []
-                            },
-                            {
-                                "@id": "_:command_create",
-                                "@type": "http://schema.org/AddAction",
-                                "description": "Create new Command entity",
-                                "expects": "vocab:Command",
-                                "method": "PUT",
-                                "returns": "vocab:Command",
-                                "expectsHeader": [],
-                                "returnsHeader": [],
                                 "possibleStatus": [
                                     {
-                                        "title": "If the Command entity was created successfully.",
-                                        "statusCode": 201,
-                                        "description": ""
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Command not found",
+                                        "statusCode": 404,
+                                        "title": ""
+                                    },
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Command Returned",
+                                        "statusCode": 200,
+                                        "title": ""
                                     }
-                                ]
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Command",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "addcommand",
+                                "@type": "http://schema.org/AddAction",
+                                "description": "null",
+                                "expects": "http://localhost:8080/api/vocab#Command",
+                                "expectsHeader": [],
+                                "label": "AddCommand",
+                                "method": "PUT",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Command added",
+                                        "statusCode": 201,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "null",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "deletecommand",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": "null",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "label": "DeleteCommand",
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Command deleted",
+                                        "statusCode": 201,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "null",
+                                "returnsHeader": []
                             }
                         ]
                     },
@@ -1086,43 +1609,62 @@ doc = {
                     "writeable": "false"
                 },
                 {
-                    "hydra:description": "The StateCollection collection",
-                    "hydra:title": "statecollection",
+                    "hydra:description": "The Message Class",
+                    "hydra:title": "message",
                     "property": {
-                        "@id": "vocab:EntryPoint/StateCollection",
+                        "@id": "http://localhost:8080/api/vocab#EntryPoint/Class for messages received by the GUI interface",
                         "@type": "hydra:Link",
-                        "description": "The StateCollection collection",
-                        "domain": "vocab:EntryPoint",
-                        "label": "StateCollection",
-                        "range": "vocab:StateCollection",
+                        "description": "Message",
+                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "label": "Message",
+                        "range": "http://localhost:8080/api/vocab#Message",
                         "supportedOperation": [
                             {
-                                "@id": "_:state_collection_retrieve",
+                                "@id": "getmessage",
                                 "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all State entities",
+                                "description": "null",
                                 "expects": "null",
+                                "expectsHeader": [],
+                                "label": "GetMessage",
                                 "method": "GET",
-                                "returns": "vocab:StateCollection",
-                                "expectsHeader": [],
-                                "returnsHeader": [],
-                                "possibleStatus": []
-                            },
-                            {
-                                "@id": "_:state_create",
-                                "@type": "http://schema.org/AddAction",
-                                "description": "Create new State entity",
-                                "expects": "vocab:State",
-                                "method": "PUT",
-                                "returns": "vocab:State",
-                                "expectsHeader": [],
-                                "returnsHeader": [],
                                 "possibleStatus": [
                                     {
-                                        "title": "If the State entity was created successfully.",
-                                        "statusCode": 201,
-                                        "description": ""
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Message not found",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    },
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Message returned",
+                                        "statusCode": 200,
+                                        "title": ""
                                     }
-                                ]
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Message",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "deletemessage",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": "null",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "label": "DeleteMessage",
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "Message deleted",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "null",
+                                "returnsHeader": []
                             }
                         ]
                     },
@@ -1134,40 +1676,84 @@ doc = {
                     "hydra:description": "The MessageCollection collection",
                     "hydra:title": "messagecollection",
                     "property": {
-                        "@id": "vocab:EntryPoint/MessageCollection",
+                        "@id": "http://localhost:8080/api/vocab#EntryPoint/MessageCollection",
                         "@type": "hydra:Link",
                         "description": "The MessageCollection collection",
-                        "domain": "vocab:EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
                         "label": "MessageCollection",
-                        "range": "vocab:MessageCollection",
+                        "manages": {
+                            "object": "http://localhost:8080/api/vocab#Message",
+                            "property": "rdfs:type"
+                        },
+                        "range": "http://localhost:8080/api/vocab#MessageCollection",
                         "supportedOperation": [
                             {
-                                "@id": "_:message_collection_retrieve",
+                                "@id": "_:messagecollection_retrieve",
                                 "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all Message entities",
+                                "description": "Retrieves all the members of MessageCollection",
                                 "expects": "null",
-                                "method": "GET",
-                                "returns": "vocab:MessageCollection",
                                 "expectsHeader": [],
-                                "returnsHeader": [],
-                                "possibleStatus": []
+                                "method": "GET",
+                                "possibleStatus": [],
+                                "returns": "http://localhost:8080/api/vocab#Message",
+                                "returnsHeader": []
                             },
                             {
-                                "@id": "_:message_create",
+                                "@id": "_:messagecollection_create",
                                 "@type": "http://schema.org/AddAction",
-                                "description": "Create new Message entity",
-                                "expects": "vocab:Message",
-                                "method": "PUT",
-                                "returns": "vocab:Message",
+                                "description": "Create new member in MessageCollection",
+                                "expects": "http://localhost:8080/api/vocab#Message",
                                 "expectsHeader": [],
-                                "returnsHeader": [],
+                                "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "title": "If the Message entity was created successfully.",
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "A new member in MessageCollection created",
                                         "statusCode": 201,
-                                        "description": ""
+                                        "title": ""
                                     }
-                                ]
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Message",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:messagecollection_update",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "Update member of  MessageCollection ",
+                                "expects": "http://localhost:8080/api/vocab#Message",
+                                "expectsHeader": [],
+                                "method": "POST",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If the entity was updatedfrom MessageCollection.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Message",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:messagecollection_delete",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": "Delete member of MessageCollection ",
+                                "expects": "http://localhost:8080/api/vocab#Message",
+                                "expectsHeader": [],
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If entity was deletedsuccessfully from MessageCollection.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Message",
+                                "returnsHeader": []
                             }
                         ]
                     },
@@ -1176,88 +1762,87 @@ doc = {
                     "writeable": "false"
                 },
                 {
-                    "hydra:description": "The DroneCollection collection",
-                    "hydra:title": "dronecollection",
+                    "hydra:description": "The StateCollection collection",
+                    "hydra:title": "statecollection",
                     "property": {
-                        "@id": "vocab:EntryPoint/DroneCollection",
+                        "@id": "http://localhost:8080/api/vocab#EntryPoint/StateCollection",
                         "@type": "hydra:Link",
-                        "description": "The DroneCollection collection",
-                        "domain": "vocab:EntryPoint",
-                        "label": "DroneCollection",
-                        "range": "vocab:DroneCollection",
+                        "description": "The StateCollection collection",
+                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "label": "StateCollection",
+                        "manages": {
+                            "object": "http://localhost:8080/api/vocab#State",
+                            "property": "rdfs:type"
+                        },
+                        "range": "http://localhost:8080/api/vocab#StateCollection",
                         "supportedOperation": [
                             {
-                                "@id": "_:drone_collection_retrieve",
+                                "@id": "_:statecollection_retrieve",
                                 "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all Drone entities",
+                                "description": "Retrieves all the members of StateCollection",
                                 "expects": "null",
-                                "method": "GET",
-                                "returns": "vocab:DroneCollection",
                                 "expectsHeader": [],
-                                "returnsHeader": [],
-                                "possibleStatus": []
+                                "method": "GET",
+                                "possibleStatus": [],
+                                "returns": "http://localhost:8080/api/vocab#State",
+                                "returnsHeader": []
                             },
                             {
-                                "@id": "_:drone_create",
+                                "@id": "_:statecollection_create",
                                 "@type": "http://schema.org/AddAction",
-                                "description": "Create new Drone entity",
-                                "expects": "vocab:Drone",
-                                "method": "PUT",
-                                "returns": "vocab:Drone",
+                                "description": "Create new member in StateCollection",
+                                "expects": "http://localhost:8080/api/vocab#State",
                                 "expectsHeader": [],
-                                "returnsHeader": [],
+                                "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "title": "If the Drone entity was created successfully.",
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "A new member in StateCollection created",
                                         "statusCode": 201,
-                                        "description": ""
+                                        "title": ""
                                     }
-                                ]
-                            }
-                        ]
-                    },
-                    "readable": "true",
-                    "required": "null",
-                    "writeable": "false"
-                },
-                {
-                    "hydra:description": "The LogEntryCollection collection",
-                    "hydra:title": "logentrycollection",
-                    "property": {
-                        "@id": "vocab:EntryPoint/LogEntryCollection",
-                        "@type": "hydra:Link",
-                        "description": "The LogEntryCollection collection",
-                        "domain": "vocab:EntryPoint",
-                        "label": "LogEntryCollection",
-                        "range": "vocab:LogEntryCollection",
-                        "supportedOperation": [
-                            {
-                                "@id": "_:logentry_collection_retrieve",
-                                "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all LogEntry entities",
-                                "expects": "null",
-                                "method": "GET",
-                                "returns": "vocab:LogEntryCollection",
-                                "expectsHeader": [],
-                                "returnsHeader": [],
-                                "possibleStatus": []
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#State",
+                                "returnsHeader": []
                             },
                             {
-                                "@id": "_:logentry_create",
-                                "@type": "http://schema.org/AddAction",
-                                "description": "Create new LogEntry entity",
-                                "expects": "vocab:LogEntry",
-                                "method": "PUT",
-                                "returns": "vocab:LogEntry",
+                                "@id": "_:statecollection_update",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "Update member of  StateCollection ",
+                                "expects": "http://localhost:8080/api/vocab#State",
                                 "expectsHeader": [],
-                                "returnsHeader": [],
+                                "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "title": "If the LogEntry entity was created successfully.",
-                                        "statusCode": 201,
-                                        "description": ""
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If the entity was updatedfrom StateCollection.",
+                                        "statusCode": 200,
+                                        "title": ""
                                     }
-                                ]
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#State",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:statecollection_delete",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": "Delete member of StateCollection ",
+                                "expects": "http://localhost:8080/api/vocab#State",
+                                "expectsHeader": [],
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If entity was deletedsuccessfully from StateCollection.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#State",
+                                "returnsHeader": []
                             }
                         ]
                     },
@@ -1269,40 +1854,262 @@ doc = {
                     "hydra:description": "The DatastreamCollection collection",
                     "hydra:title": "datastreamcollection",
                     "property": {
-                        "@id": "vocab:EntryPoint/DatastreamCollection",
+                        "@id": "http://localhost:8080/api/vocab#EntryPoint/DatastreamCollection",
                         "@type": "hydra:Link",
                         "description": "The DatastreamCollection collection",
-                        "domain": "vocab:EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
                         "label": "DatastreamCollection",
-                        "range": "vocab:DatastreamCollection",
+                        "manages": {
+                            "object": "http://localhost:8080/api/vocab#Datastream",
+                            "property": "rdfs:type"
+                        },
+                        "range": "http://localhost:8080/api/vocab#DatastreamCollection",
                         "supportedOperation": [
                             {
-                                "@id": "_:datastream_collection_retrieve",
+                                "@id": "_:datastreamcollection_retrieve",
                                 "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all Datastream entities",
+                                "description": "Retrieves all the members of DatastreamCollection",
                                 "expects": "null",
-                                "method": "GET",
-                                "returns": "vocab:DatastreamCollection",
                                 "expectsHeader": [],
-                                "returnsHeader": [],
-                                "possibleStatus": []
+                                "method": "GET",
+                                "possibleStatus": [],
+                                "returns": "http://localhost:8080/api/vocab#Datastream",
+                                "returnsHeader": []
                             },
                             {
-                                "@id": "_:datastream_create",
+                                "@id": "_:datastreamcollection_create",
                                 "@type": "http://schema.org/AddAction",
-                                "description": "Create new Datastream entitity",
-                                "expects": "vocab:Datastream",
-                                "method": "PUT",
-                                "returns": "vocab:Datastream",
+                                "description": "Create new member in DatastreamCollection",
+                                "expects": "http://localhost:8080/api/vocab#Datastream",
                                 "expectsHeader": [],
-                                "returnsHeader": [],
+                                "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "title": "If the Datastream entity was created successfully.",
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "A new member in DatastreamCollection created",
                                         "statusCode": 201,
-                                        "description": ""
+                                        "title": ""
                                     }
-                                ]
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Datastream",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:datastreamcollection_update",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "Update member of  DatastreamCollection ",
+                                "expects": "http://localhost:8080/api/vocab#Datastream",
+                                "expectsHeader": [],
+                                "method": "POST",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If the entity was updatedfrom DatastreamCollection.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Datastream",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:datastreamcollection_delete",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": "Delete member of DatastreamCollection ",
+                                "expects": "http://localhost:8080/api/vocab#Datastream",
+                                "expectsHeader": [],
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If entity was deletedsuccessfully from DatastreamCollection.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Datastream",
+                                "returnsHeader": []
+                            }
+                        ]
+                    },
+                    "readable": "true",
+                    "required": "null",
+                    "writeable": "false"
+                },
+                {
+                    "hydra:description": "The LogEntryCollection collection",
+                    "hydra:title": "logentrycollection",
+                    "property": {
+                        "@id": "http://localhost:8080/api/vocab#EntryPoint/LogEntryCollection",
+                        "@type": "hydra:Link",
+                        "description": "The LogEntryCollection collection",
+                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "label": "LogEntryCollection",
+                        "manages": {
+                            "object": "http://localhost:8080/api/vocab#LogEntry",
+                            "property": "rdfs:type"
+                        },
+                        "range": "http://localhost:8080/api/vocab#LogEntryCollection",
+                        "supportedOperation": [
+                            {
+                                "@id": "_:logentrycollection_retrieve",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "Retrieves all the members of LogEntryCollection",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "method": "GET",
+                                "possibleStatus": [],
+                                "returns": "http://localhost:8080/api/vocab#LogEntry",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:logentrycollection_create",
+                                "@type": "http://schema.org/AddAction",
+                                "description": "Create new member in LogEntryCollection",
+                                "expects": "http://localhost:8080/api/vocab#LogEntry",
+                                "expectsHeader": [],
+                                "method": "PUT",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "A new member in LogEntryCollection created",
+                                        "statusCode": 201,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#LogEntry",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:logentrycollection_update",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "Update member of  LogEntryCollection ",
+                                "expects": "http://localhost:8080/api/vocab#LogEntry",
+                                "expectsHeader": [],
+                                "method": "POST",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If the entity was updatedfrom LogEntryCollection.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#LogEntry",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:logentrycollection_delete",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": "Delete member of LogEntryCollection ",
+                                "expects": "http://localhost:8080/api/vocab#LogEntry",
+                                "expectsHeader": [],
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If entity was deletedsuccessfully from LogEntryCollection.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#LogEntry",
+                                "returnsHeader": []
+                            }
+                        ]
+                    },
+                    "readable": "true",
+                    "required": "null",
+                    "writeable": "false"
+                },
+                {
+                    "hydra:description": "The CommandCollection collection",
+                    "hydra:title": "commandcollection",
+                    "property": {
+                        "@id": "http://localhost:8080/api/vocab#EntryPoint/CommandCollection",
+                        "@type": "hydra:Link",
+                        "description": "The CommandCollection collection",
+                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "label": "CommandCollection",
+                        "manages": {
+                            "object": "http://localhost:8080/api/vocab#Command",
+                            "property": "rdfs:type"
+                        },
+                        "range": "http://localhost:8080/api/vocab#CommandCollection",
+                        "supportedOperation": [
+                            {
+                                "@id": "_:commandcollection_retrieve",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "Retrieves all the members of CommandCollection",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "method": "GET",
+                                "possibleStatus": [],
+                                "returns": "http://localhost:8080/api/vocab#Command",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:commandcollection_create",
+                                "@type": "http://schema.org/AddAction",
+                                "description": "Create new member in CommandCollection",
+                                "expects": "http://localhost:8080/api/vocab#Command",
+                                "expectsHeader": [],
+                                "method": "PUT",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "A new member in CommandCollection created",
+                                        "statusCode": 201,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Command",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:commandcollection_update",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "Update member of  CommandCollection ",
+                                "expects": "http://localhost:8080/api/vocab#Command",
+                                "expectsHeader": [],
+                                "method": "POST",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If the entity was updatedfrom CommandCollection.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Command",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:commandcollection_delete",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": "Delete member of CommandCollection ",
+                                "expects": "http://localhost:8080/api/vocab#Command",
+                                "expectsHeader": [],
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If entity was deletedsuccessfully from CommandCollection.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab#Command",
+                                "returnsHeader": []
                             }
                         ]
                     },

--- a/hydrus/tests/conftest.py
+++ b/hydrus/tests/conftest.py
@@ -218,15 +218,7 @@ def init_db_for_crud_tests(drone_doc, session, engine):
     Drone Api test HydraDoc object.
     """
     test_classes, test_properties = get_doc_classes_and_properties(drone_doc)
-    try:
-        create_database_tables(test_classes)
-    except Exception:
-        # catch error when the tables have been already defined.
-        # happens when /test_socket.py is run after /test_app.py
-        # in the same session
-        # in that case, no need to create the tables again on the
-        # same sqlalchemy.ext.declarative.declarative_base instance
-        pass
+    create_database_tables(test_classes)
     Base.metadata.create_all(engine)
 
 

--- a/hydrus/tests/conftest.py
+++ b/hydrus/tests/conftest.py
@@ -207,8 +207,8 @@ def drone_doc(constants):
 
 
 @pytest.fixture(scope='module')
-def drone_doc_collection_classes(drone_doc):
-    return [drone_doc.collections[i]['collection'].class_.title for i in drone_doc.collections]
+def drone_doc_parsed_classes(drone_doc):
+    return [drone_doc.parsed_classes[i]['class'].title for i in drone_doc.parsed_classes]
 
 
 @pytest.fixture(scope='module')

--- a/hydrus/tests/conftest.py
+++ b/hydrus/tests/conftest.py
@@ -28,7 +28,7 @@ def get_doc_classes_and_properties(doc):
     :return: classes and properties in the HydraDoc object in a tuple
     :rtype: tuple(list, set)
     """
-    test_classes = doc_parse.get_classes(doc.generate())
+    test_classes = doc_parse.get_classes(doc)
     test_properties = doc_parse.get_all_properties(test_classes)
     return (test_classes, test_properties)
 

--- a/hydrus/tests/conftest.py
+++ b/hydrus/tests/conftest.py
@@ -5,7 +5,7 @@ from base64 import b64encode
 
 import pytest
 from hydra_python_core import doc_maker
-from hydra_python_core.doc_writer import HydraLink
+from hydra_python_core.doc_writer import HydraLink, DocUrl
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 
@@ -43,6 +43,7 @@ def gen_dummy_object(class_title, doc):
     object_ = {
         "@type": class_title
     }
+    expanded_base_url = DocUrl.doc_url
     for class_path in doc.collections:
         if class_title == doc.collections[class_path]["collection"].name:
             members = [str(uuid.uuid4()) for _ in range(3)]
@@ -57,8 +58,8 @@ def gen_dummy_object(class_title, doc):
                     object_[prop.title] = ''.join(random.choice(
                         string.ascii_uppercase + string.digits) for _ in range(6))
                     pass
-                elif "vocab:" in prop.prop:
-                    prop_class = prop.prop.replace("vocab:", "")
+                elif expanded_base_url in prop.prop:
+                    prop_class = prop.prop.split(expanded_base_url)[1]
                     object_[prop.title] = gen_dummy_object(prop_class, doc)
                 else:
                     object_[prop.title] = ''.join(random.choice(

--- a/hydrus/tests/conftest.py
+++ b/hydrus/tests/conftest.py
@@ -218,7 +218,15 @@ def init_db_for_crud_tests(drone_doc, session, engine):
     Drone Api test HydraDoc object.
     """
     test_classes, test_properties = get_doc_classes_and_properties(drone_doc)
-    create_database_tables(test_classes)
+    try:
+        create_database_tables(test_classes)
+    except Exception:
+        # catch error when the tables have been already defined.
+        # happens when /test_socket.py is run after /test_app.py
+        # in the same session
+        # in that case, no need to create the tables again on the
+        # same sqlalchemy.ext.declarative.declarative_base instance
+        pass
     Base.metadata.create_all(engine)
 
 

--- a/hydrus/tests/functional/test_socket.py
+++ b/hydrus/tests/functional/test_socket.py
@@ -72,7 +72,7 @@ class TestSocket:
                 class_name = '/'.join(endpoints[endpoint].split(f'/{API_NAME}/')[1:])
                 class_ = doc.parsed_classes[class_name]['class']
                 class_methods = [x.method for x in class_.supportedOperation]
-                if 'POST' in class_methods:
+                if 'PUT' in class_methods:
                     # insert a object to be updated later
                     dummy_object = gen_dummy_object(class_.title, doc)
                     put_response = test_app_client.put(
@@ -83,17 +83,18 @@ class TestSocket:
                     # Flush old socketio updates
                     socketio_client.get_received('/sync')
                     # POST object
-                    new_dummy_object = gen_dummy_object(class_.title, doc)
-                    post_response = test_app_client.post(
-                        f'{endpoints[endpoint]}/{id_}',
-                        data=json.dumps(new_dummy_object))
-                    assert post_response.status_code == 200
-                    # Get new socketio update
-                    update = socketio_client.get_received('/sync')
-                    assert len(update) != 0
-                    assert update[0]['args'][0]['method'] == 'POST'
-                    resource_name = update[0]['args'][0]['resource_url'].split('/')[-2]
-                    assert resource_name == endpoints[endpoint].split('/')[-1]
+                    if 'POST' in class_methods:
+                        new_dummy_object = gen_dummy_object(class_.title, doc)
+                        post_response = test_app_client.post(
+                            f'{endpoints[endpoint]}/{id_}',
+                            data=json.dumps(new_dummy_object))
+                        assert post_response.status_code == 200
+                        # Get new socketio update
+                        update = socketio_client.get_received('/sync')
+                        assert len(update) != 0
+                        assert update[0]['args'][0]['method'] == 'POST'
+                        resource_name = update[0]['args'][0]['resource_url'].split('/')[-2]
+                        assert resource_name == endpoints[endpoint].split('/')[-1]
 
     def test_socketio_DELETE_updates(self, socketio_client, test_app_client, constants, doc):
         """Test 'update' event emitted by socketio for DELETE operations."""
@@ -106,7 +107,7 @@ class TestSocket:
                 class_name = '/'.join(endpoints[endpoint].split(f'/{API_NAME}/')[1:])
                 class_ = doc.parsed_classes[class_name]['class']
                 class_methods = [x.method for x in class_.supportedOperation]
-                if 'DELETE' in class_methods:
+                if 'PUT' in class_methods:
                     # insert a object first to be deleted later
                     dummy_object = gen_dummy_object(class_.title, doc)
                     put_response = test_app_client.put(
@@ -116,11 +117,12 @@ class TestSocket:
                     id_ = desc.split('ID ')[1].split(' successfully')[0]
                     # Flush old socketio updates
                     socketio_client.get_received('/sync')
-                    delete_response = test_app_client.delete(f'{endpoints[endpoint]}/{id_}')
-                    assert delete_response.status_code == 200
-                    # Get new update event
-                    update = socketio_client.get_received('/sync')
-                    assert len(update) != 0
-                    assert update[0]['args'][0]['method'] == 'DELETE'
-                    resource_name = update[0]['args'][0]['resource_url'].split('/')[-2]
-                    assert resource_name == endpoints[endpoint].split('/')[-1]
+                    if 'DELETE' in class_methods:
+                        delete_response = test_app_client.delete(f'{endpoints[endpoint]}/{id_}')
+                        assert delete_response.status_code == 200
+                        # Get new update event
+                        update = socketio_client.get_received('/sync')
+                        assert len(update) != 0
+                        assert update[0]['args'][0]['method'] == 'DELETE'
+                        resource_name = update[0]['args'][0]['resource_url'].split('/')[-2]
+                        assert resource_name == endpoints[endpoint].split('/')[-1]

--- a/hydrus/tests/functional/test_socket.py
+++ b/hydrus/tests/functional/test_socket.py
@@ -68,33 +68,32 @@ class TestSocket:
         assert index.status_code == 200
         endpoints = json.loads(index.data.decode('utf-8'))
         for endpoint in endpoints:
-            if endpoint not in ['@context', '@id', '@type']:
+            if endpoint not in ['@context', '@id', '@type', 'collections']:
                 class_name = '/'.join(endpoints[endpoint].split(f'/{API_NAME}/')[1:])
-                if class_name not in doc.collections:
-                    class_ = doc.parsed_classes[class_name]['class']
-                    class_methods = [x.method for x in class_.supportedOperation]
-                    if 'POST' in class_methods:
-                        # insert a object to be updated later
-                        dummy_object = gen_dummy_object(class_.title, doc)
-                        put_response = test_app_client.put(
-                            endpoints[endpoint], data=json.dumps(dummy_object))
-                        # extract id of the created object from the description of response
-                        desc = put_response.json['description']
-                        id_ = desc.split('ID ')[1].split(' successfully')[0]
-                        # Flush old socketio updates
-                        socketio_client.get_received('/sync')
-                        # POST object
-                        new_dummy_object = gen_dummy_object(class_.title, doc)
-                        post_response = test_app_client.post(
-                            f'{endpoints[endpoint]}/{id_}',
-                            data=json.dumps(new_dummy_object))
-                        assert post_response.status_code == 200
-                        # Get new socketio update
-                        update = socketio_client.get_received('/sync')
-                        assert len(update) != 0
-                        assert update[0]['args'][0]['method'] == 'POST'
-                        resource_name = update[0]['args'][0]['resource_url'].split('/')[-2]
-                        assert resource_name == endpoints[endpoint].split('/')[-1]
+                class_ = doc.parsed_classes[class_name]['class']
+                class_methods = [x.method for x in class_.supportedOperation]
+                if 'POST' in class_methods:
+                    # insert a object to be updated later
+                    dummy_object = gen_dummy_object(class_.title, doc)
+                    put_response = test_app_client.put(
+                        endpoints[endpoint], data=json.dumps(dummy_object))
+                    # extract id of the created object from the description of response
+                    desc = put_response.json['description']
+                    id_ = desc.split('ID ')[1].split(' successfully')[0]
+                    # Flush old socketio updates
+                    socketio_client.get_received('/sync')
+                    # POST object
+                    new_dummy_object = gen_dummy_object(class_.title, doc)
+                    post_response = test_app_client.post(
+                        f'{endpoints[endpoint]}/{id_}',
+                        data=json.dumps(new_dummy_object))
+                    assert post_response.status_code == 200
+                    # Get new socketio update
+                    update = socketio_client.get_received('/sync')
+                    assert len(update) != 0
+                    assert update[0]['args'][0]['method'] == 'POST'
+                    resource_name = update[0]['args'][0]['resource_url'].split('/')[-2]
+                    assert resource_name == endpoints[endpoint].split('/')[-1]
 
     def test_socketio_DELETE_updates(self, socketio_client, test_app_client, constants, doc):
         """Test 'update' event emitted by socketio for DELETE operations."""
@@ -103,26 +102,25 @@ class TestSocket:
         assert index.status_code == 200
         endpoints = json.loads(index.data.decode('utf-8'))
         for endpoint in endpoints:
-            if endpoint not in ['@context', '@id', '@type']:
+            if endpoint not in ['@context', '@id', '@type', 'collections']:
                 class_name = '/'.join(endpoints[endpoint].split(f'/{API_NAME}/')[1:])
-                if class_name not in doc.collections:
-                    class_ = doc.parsed_classes[class_name]['class']
-                    class_methods = [x.method for x in class_.supportedOperation]
-                    if 'DELETE' in class_methods:
-                        # insert a object first to be deleted later
-                        dummy_object = gen_dummy_object(class_.title, doc)
-                        put_response = test_app_client.put(
-                            endpoints[endpoint], data=json.dumps(dummy_object))
-                        # extract id of the created object from the description of response
-                        desc = put_response.json['description']
-                        id_ = desc.split('ID ')[1].split(' successfully')[0]
-                        # Flush old socketio updates
-                        socketio_client.get_received('/sync')
-                        delete_response = test_app_client.delete(f'{endpoints[endpoint]}/{id_}')
-                        assert delete_response.status_code == 200
-                        # Get new update event
-                        update = socketio_client.get_received('/sync')
-                        assert len(update) != 0
-                        assert update[0]['args'][0]['method'] == 'DELETE'
-                        resource_name = update[0]['args'][0]['resource_url'].split('/')[-2]
-                        assert resource_name == endpoints[endpoint].split('/')[-1]
+                class_ = doc.parsed_classes[class_name]['class']
+                class_methods = [x.method for x in class_.supportedOperation]
+                if 'DELETE' in class_methods:
+                    # insert a object first to be deleted later
+                    dummy_object = gen_dummy_object(class_.title, doc)
+                    put_response = test_app_client.put(
+                        endpoints[endpoint], data=json.dumps(dummy_object))
+                    # extract id of the created object from the description of response
+                    desc = put_response.json['description']
+                    id_ = desc.split('ID ')[1].split(' successfully')[0]
+                    # Flush old socketio updates
+                    socketio_client.get_received('/sync')
+                    delete_response = test_app_client.delete(f'{endpoints[endpoint]}/{id_}')
+                    assert delete_response.status_code == 200
+                    # Get new update event
+                    update = socketio_client.get_received('/sync')
+                    assert len(update) != 0
+                    assert update[0]['args'][0]['method'] == 'DELETE'
+                    resource_name = update[0]['args'][0]['resource_url'].split('/')[-2]
+                    assert resource_name == endpoints[endpoint].split('/')[-1]

--- a/hydrus/tests/unit/test_crud.py
+++ b/hydrus/tests/unit/test_crud.py
@@ -12,19 +12,19 @@ from hydrus.data.exceptions import PropertyNotGiven
 from hydrus.tests.conftest import gen_dummy_object
 
 
-def test_crud_insert_response_is_str(drone_doc_collection_classes, drone_doc, session,
+def test_crud_insert_response_is_str(drone_doc_parsed_classes, drone_doc, session,
                                      init_db_for_crud_tests):
     """Test CRUD insert response is string"""
-    object_ = gen_dummy_object(random.choice(drone_doc_collection_classes), drone_doc)
+    object_ = gen_dummy_object(random.choice(drone_doc_parsed_classes), drone_doc)
     id_ = str(uuid.uuid4())
     response = crud.insert(object_=object_, id_=id_, session=session)
 
     assert isinstance(response, str)
 
 
-def test_crud_get_returns_correct_object(drone_doc_collection_classes, drone_doc, session):
+def test_crud_get_returns_correct_object(drone_doc_parsed_classes, drone_doc, session):
     """Test CRUD get returns correct object"""
-    object_ = gen_dummy_object(random.choice(drone_doc_collection_classes), drone_doc)
+    object_ = gen_dummy_object(random.choice(drone_doc_parsed_classes), drone_doc)
     id_ = str(uuid.uuid4())
     response = crud.insert(object_=object_, id_=id_, session=session)
     object_ = crud.get(id_=id_, type_=object_['@type'], session=session, api_name='api')
@@ -32,10 +32,10 @@ def test_crud_get_returns_correct_object(drone_doc_collection_classes, drone_doc
     assert object_['@id'].split('/')[-1] == id_
 
 
-def test_get_for_nested_obj(drone_doc_collection_classes, drone_doc, session, constants):
+def test_get_for_nested_obj(drone_doc_parsed_classes, drone_doc, session, constants):
     """Test CRUD get operation for object that can contain other objects."""
     expanded_base_url = DocUrl.doc_url
-    for class_ in drone_doc_collection_classes:
+    for class_ in drone_doc_parsed_classes:
         for prop in drone_doc.parsed_classes[class_]['class'].supportedProperty:
             if not isinstance(prop.prop, HydraLink):
                 if expanded_base_url in prop.prop:
@@ -53,10 +53,10 @@ def test_get_for_nested_obj(drone_doc_collection_classes, drone_doc, session, co
                     break
 
 
-def test_searching_over_collection_elements(drone_doc_collection_classes, drone_doc, session):
+def test_searching_over_collection_elements(drone_doc_parsed_classes, drone_doc, session):
     """Test searching over collection elements."""
     expanded_base_url = DocUrl.doc_url
-    for class_ in drone_doc_collection_classes:
+    for class_ in drone_doc_parsed_classes:
         target_property_1 = ''
         target_property_2 = ''
         for prop in drone_doc.parsed_classes[class_]['class'].supportedProperty:
@@ -102,9 +102,9 @@ def test_searching_over_collection_elements(drone_doc_collection_classes, drone_
                 break
 
 
-def test_update_on_object(drone_doc_collection_classes, drone_doc, session):
+def test_update_on_object(drone_doc_parsed_classes, drone_doc, session):
     """Test CRUD update on object"""
-    random_class = random.choice(drone_doc_collection_classes)
+    random_class = random.choice(drone_doc_parsed_classes)
     object_ = gen_dummy_object(random_class, drone_doc)
     new_object = gen_dummy_object(random_class, drone_doc)
     id_ = str(uuid.uuid4())
@@ -122,9 +122,9 @@ def test_update_on_object(drone_doc_collection_classes, drone_doc, session):
     assert test_object['@id'].split('/')[-1] == id_
 
 
-def test_delete_on_object(drone_doc_collection_classes, drone_doc, session):
+def test_delete_on_object(drone_doc_parsed_classes, drone_doc, session):
     """Test CRUD delete on object"""
-    object_ = gen_dummy_object(random.choice(drone_doc_collection_classes), drone_doc)
+    object_ = gen_dummy_object(random.choice(drone_doc_parsed_classes), drone_doc)
     id_ = str(uuid.uuid4())
     insert_response = crud.insert(object_=object_, id_=id_, session=session)
     assert isinstance(insert_response, str)
@@ -142,10 +142,10 @@ def test_delete_on_object(drone_doc_collection_classes, drone_doc, session):
     assert 404 == response_code
 
 
-def test_get_on_wrong_id(drone_doc_collection_classes, drone_doc, session):
+def test_get_on_wrong_id(drone_doc_parsed_classes, drone_doc, session):
     """Test CRUD get when wrong/undefined ID is given."""
     id_ = str(uuid.uuid4())
-    type_ = random.choice(drone_doc_collection_classes)
+    type_ = random.choice(drone_doc_parsed_classes)
     response_code = None
     try:
         get_response = crud.get(id_=id_, type_=type_, session=session, api_name='api')
@@ -155,10 +155,10 @@ def test_get_on_wrong_id(drone_doc_collection_classes, drone_doc, session):
     assert 404 == response_code
 
 
-def test_delete_on_wrong_id(drone_doc_collection_classes, drone_doc, session):
+def test_delete_on_wrong_id(drone_doc_parsed_classes, drone_doc, session):
     """Test CRUD delete when wrong/undefined ID is given."""
     object_ = gen_dummy_object(random.choice(
-        drone_doc_collection_classes), drone_doc)
+        drone_doc_parsed_classes), drone_doc)
     id_ = str(uuid.uuid4())
     insert_response = crud.insert(object_=object_, id_=id_, session=session)
     response_code = None
@@ -172,9 +172,9 @@ def test_delete_on_wrong_id(drone_doc_collection_classes, drone_doc, session):
     assert insert_response == id_
 
 
-def test_insert_used_id(drone_doc_collection_classes, drone_doc, session):
+def test_insert_used_id(drone_doc_parsed_classes, drone_doc, session):
     """Test CRUD insert when used ID is given."""
-    object_ = gen_dummy_object(random.choice(drone_doc_collection_classes), drone_doc)
+    object_ = gen_dummy_object(random.choice(drone_doc_parsed_classes), drone_doc)
     id_ = str(uuid.uuid4())
     insert_response = crud.insert(object_=object_, id_=id_, session=session)
     response_code = None
@@ -199,9 +199,9 @@ def test_get_on_wrong_type(session):
     assert 400 == error.code
 
 
-def test_delete_on_wrong_type(drone_doc_collection_classes, drone_doc, session):
+def test_delete_on_wrong_type(drone_doc_parsed_classes, drone_doc, session):
     """Test CRUD delete when wrong/undefined class is given."""
-    object_ = gen_dummy_object(random.choice(drone_doc_collection_classes), drone_doc)
+    object_ = gen_dummy_object(random.choice(drone_doc_parsed_classes), drone_doc)
     id_ = str(uuid.uuid4())
     insert_response = crud.insert(object_=object_, id_=id_, session=session)
     assert isinstance(insert_response, str)
@@ -215,9 +215,9 @@ def test_delete_on_wrong_type(drone_doc_collection_classes, drone_doc, session):
     assert 400 == response_code
 
 
-def test_insert_on_wrong_type(drone_doc_collection_classes, drone_doc, session):
+def test_insert_on_wrong_type(drone_doc_parsed_classes, drone_doc, session):
     """Test CRUD insert when wrong/undefined class is given."""
-    object_ = gen_dummy_object(random.choice(drone_doc_collection_classes), drone_doc)
+    object_ = gen_dummy_object(random.choice(drone_doc_parsed_classes), drone_doc)
     id_ = str(uuid.uuid4())
     object_['@type'] = 'otherClass'
     response_code = None
@@ -229,24 +229,24 @@ def test_insert_on_wrong_type(drone_doc_collection_classes, drone_doc, session):
     assert 400 == response_code
 
 
-def test_insert_multiple_id(drone_doc_collection_classes, drone_doc, session):
+def test_insert_multiple_id(drone_doc_parsed_classes, drone_doc, session):
     """Test CRUD insert when multiple ID's are given """
     objects = list()
     ids = '{},{}'.format(str(uuid.uuid4()), str(uuid.uuid4()))
     ids_list = ids.split(',')
     for index in range(len(ids_list)):
-        object = gen_dummy_object(random.choice(drone_doc_collection_classes), drone_doc)
+        object = gen_dummy_object(random.choice(drone_doc_parsed_classes), drone_doc)
         objects.append(object)
     insert_response = crud.insert_multiple(objects_=objects, session=session, id_=ids)
     for id_ in ids_list:
         assert id_ in insert_response
 
 
-def test_delete_multiple_id(drone_doc_collection_classes, drone_doc, session):
+def test_delete_multiple_id(drone_doc_parsed_classes, drone_doc, session):
     """Test CRUD insert when multiple ID's are given """
     objects = list()
     ids = '{},{}'.format(str(uuid.uuid4()), str(uuid.uuid4()))
-    random_class = random.choice(drone_doc_collection_classes)
+    random_class = random.choice(drone_doc_parsed_classes)
     for index in range(len(ids.split(','))):
         object = gen_dummy_object(random_class, drone_doc)
         objects.append(object)
@@ -268,14 +268,15 @@ def test_delete_multiple_id(drone_doc_collection_classes, drone_doc, session):
     assert 404 == response_code
 
 
-def test_insert_when_property_not_given(drone_doc_collection_classes, drone_doc,
+def test_insert_when_property_not_given(drone_doc_parsed_classes, drone_doc,
                                         session, constants):
     """Test CRUD insert operation when a required foreign key
     property of that resource(column in the table) not given"""
     expanded_base_url = DocUrl.doc_url
-    for class_ in drone_doc_collection_classes:
+    for class_ in drone_doc_parsed_classes:
         for prop in drone_doc.parsed_classes[class_]['class'].supportedProperty:
             if isinstance(prop.prop, HydraLink) or expanded_base_url in prop.prop:
+                import pdb;pdb.set_trace()
                 dummy_obj = gen_dummy_object(class_, drone_doc)
                 if isinstance(prop.prop, HydraLink):
                     nested_class = prop.prop.range.split(expanded_base_url)[1]

--- a/hydrus/tests/unit/test_crud.py
+++ b/hydrus/tests/unit/test_crud.py
@@ -276,7 +276,6 @@ def test_insert_when_property_not_given(drone_doc_parsed_classes, drone_doc,
     for class_ in drone_doc_parsed_classes:
         for prop in drone_doc.parsed_classes[class_]['class'].supportedProperty:
             if isinstance(prop.prop, HydraLink) or expanded_base_url in prop.prop:
-                import pdb;pdb.set_trace()
                 dummy_obj = gen_dummy_object(class_, drone_doc)
                 if isinstance(prop.prop, HydraLink):
                     nested_class = prop.prop.range.split(expanded_base_url)[1]

--- a/hydrus/tests/unit/test_crud.py
+++ b/hydrus/tests/unit/test_crud.py
@@ -275,15 +275,12 @@ def test_insert_when_property_not_given(drone_doc_parsed_classes, drone_doc,
     expanded_base_url = DocUrl.doc_url
     for class_ in drone_doc_parsed_classes:
         for prop in drone_doc.parsed_classes[class_]['class'].supportedProperty:
-            if isinstance(prop.prop, HydraLink) or expanded_base_url in prop.prop:
+            if not isinstance(prop.prop, HydraLink) and expanded_base_url in prop.prop:
                 dummy_obj = gen_dummy_object(class_, drone_doc)
-                if isinstance(prop.prop, HydraLink):
-                    nested_class = prop.prop.range.split(expanded_base_url)[1]
-                else:
-                    nested_class = prop.prop.split(expanded_base_url)[1]
+                nested_prop_title = prop.title
                 continue
     # remove the foreign key resource on purpose for testing
-    dummy_obj.pop(nested_class)
+    dummy_obj.pop(nested_prop_title)
     id_ = str(uuid.uuid4())
     try:
         insert_response = crud.insert(object_=dummy_obj, id_=id_, session=session)


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #482 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
`hydrus` depended on the `vocab` keyword in a lot of places for essential operations like identifying foreign key relationships, etc.
This was not ideal behaviour.

After support for expanded API DOCs was added in `hydra-python-core` repo in PR https://github.com/HTTP-APIs/hydra-python-core/pull/42, the core library now returns an expanded APIDOC.

So, in this PR, added support for expanded API DOC.

**Note:** The build is failing currently due to some minor bugs in the core repo which @priyanshunayan is currently fixing.

