### PR TITLE
Adding Collection keyword in hydra_doc_sample.py

### DIFF
--- a/hydrus/samples/hydra_doc_sample.py
+++ b/hydrus/samples/hydra_doc_sample.py
@@ -4,6 +4,7 @@ Generated API Documentation for Server API using server_doc_gen.py."""
 doc = {
     "@context": {
         "ApiDocumentation": "hydra:ApiDocumentation",
+        "Collection":"hydra:collection",
         "description": "hydra:description",
         "domain": {
             "@id": "rdfs:domain",


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #502 
I had previously opened a PR for this issue but there were some unrelated commits in that PR. My apologies for that and taking some time to fix it. Hence, I opened a fresh PR because there were too many commits to drop from the previous PR which I closed.
### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.6.0 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Adds the "Collection" keyword in the context of the vocab of the sample doc which was earlier missing. 
### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->
Added ```"Collection":"hydra:collection"```  in hydra_doc_sample.py file which adds context to the "Collection" type for all collections. 

<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
