### PR TITLE
Fixed Port Number in README and the startup demo now serves at api/

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ hydrus uses the [Hydra(W3C)](http://www.hydra-cg.com/) standard for creation and
 Start-up the demo
 -----------------
 * with *Docker* and *docker-compose* installed, run `docker-compose up --build`
-* open the browser at `http://localhost:8000/api/vocab`
+* open the browser at `http://localhost:8080/api/vocab`
 
 You should be displaying the example API as served by the server.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       # - HYDRUS_SERVER_URL=http://192.168.99.100:8081/ ## For windows 10
       # - HYDRUS_SERVER_URL=http://54.169.232.177:8080/
       - DEBUG=1
-      - API_NAME=serverapi
+      - API_NAME=api
       # relative path to the ApiDoc, from the project root
       - APIDOC_REL_PATH=hydrus/samples/hydra_doc_sample.py
       - DB_URL=sqlite:///database.db


### PR DESCRIPTION

<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #519 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.6.0 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
The port number is now fixed in the read me which previously showed 8000. 
the startup demo now serves at `http://localhost:8080/api/vocab` 

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->


![Screenshot_2](https://user-images.githubusercontent.com/51374812/96242434-175ce200-0fc1-11eb-9df0-3b503f4262ad.png)
