### PR TITLE
Added domain name for IRI in the API

### DIFF
--- a/hydrus/conf.py
+++ b/hydrus/conf.py
@@ -86,6 +86,14 @@ def load_apidoc(path):
         raise
 
 
+def get_host_domain():
+    """
+    Returns host domain.
+    """
+    HOST_DOMAIN = f'http://localhost:{PORT}'
+    return HOST_DOMAIN
+
+
 (path, FOUND_DOC) = get_apidoc_path()
 APIDOC_OBJ = load_apidoc(path)
 HYDRUS_SERVER_URL = f'http://localhost:{PORT}/'

--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -58,6 +58,7 @@ from hydrus.data.resource_based_classes import (
     get_single_response,
     get_database_class
 )
+from hydrus.conf import get_host_domain
 
 
 def get(id_: str, type_: str, api_name: str, session: scoped_session,
@@ -430,7 +431,7 @@ def pagination(filtered_instances, path, type_, API_NAME,
     :return: response containing a page of the objects of that particular type_
     """
     collection_template = {
-        "@id": f"/{API_NAME}/{path}/",
+        "@id": f"{get_host_domain()}/{API_NAME}/{path}/",
         "@context": None,
         "@type": f"{path}",
         "members": list()
@@ -449,7 +450,7 @@ def pagination(filtered_instances, path, type_, API_NAME,
         current_page_size = result_length - offset
     for i in range(offset, offset+current_page_size):
         object_template = {
-            "@id": f"/{API_NAME}/{type_}/{filtered_instances[i].id}",
+            "@id": f"{get_host_domain()}/{API_NAME}/{type_}/{filtered_instances[i].id}",
             "@type": type_
         }
         collection_template["members"].append(object_template)

--- a/hydrus/data/crud_helpers.py
+++ b/hydrus/data/crud_helpers.py
@@ -10,6 +10,7 @@ from hydrus.data.exceptions import (
     IncompatibleParameters,
     OffsetOutOfRange,
 )
+from hydrus.conf import get_host_domain
 
 
 def recreate_iri(API_NAME: str, path: str, search_params: Dict[str, Any]) -> str:
@@ -138,10 +139,10 @@ def attach_hydra_view(collection_template: Dict[str, Any], paginate_param: str,
     """
     if paginate_param == "offset":
         collection_template["hydra:view"] = {
-            "@id": f"{iri}{paginate_param}={offset}",
+            "@id": f"{get_host_domain()}{iri}{paginate_param}={offset}",
             "@type": "hydra:PartialCollectionView",
-            "hydra:first": f"{iri}{paginate_param}=0",
-            "hydra:last": f"{iri}{paginate_param}={result_length - page_size}"
+            "hydra:first": f"{get_host_domain()}{iri}{paginate_param}=0",
+            "hydra:last": f"{get_host_domain()}{iri}{paginate_param}={result_length - page_size}"
         }
         if offset > page_size:
             collection_template["hydra:view"]["hydra:previous"] = (
@@ -151,10 +152,10 @@ def attach_hydra_view(collection_template: Dict[str, Any], paginate_param: str,
                 f"{iri}{paginate_param}={offset + page_size}")
     else:
         collection_template["hydra:view"] = {
-            "@id": f"{iri}{paginate_param}={page}",
+            "@id": f"{get_host_domain()}{iri}{paginate_param}={page}",
             "@type": "hydra:PartialCollectionView",
-            "hydra:first": f"{iri}{paginate_param}=1",
-            "hydra:last": f"{iri}{paginate_param}={last}"
+            "hydra:first": f"{get_host_domain()}{iri}{paginate_param}=1",
+            "hydra:last": f"{get_host_domain()}{iri}{paginate_param}={last}"
         }
         if page != 1:
             collection_template["hydra:view"]["hydra:previous"] = (

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -9,6 +9,7 @@ from hydrus.utils import get_collections_and_parsed_classes
 from hydra_python_core.doc_writer import HydraIriTemplate, IriTemplateMapping, HydraLink
 from hydra_python_core.doc_writer import HydraError, DocUrl
 from hydrus.socketio_factory import socketio
+from hydrus.conf import get_host_domain
 
 
 def validObject(object_: Dict[str, Any]) -> bool:
@@ -82,10 +83,10 @@ def hydrafy(object_: Dict[str, Any], path: Optional[str]) -> Dict[str, Any]:
     """
     if path == object_["@type"]:
         object_[
-            "@context"] = f"/{get_api_name()}/contexts/{object_['@type']}.jsonld"
+            "@context"] = f"{get_host_domain()}/{get_api_name()}/contexts/{object_['@type']}.jsonld"
     else:
         object_[
-            "@context"] = f"/{get_api_name()}/contexts/{path}.jsonld"
+            "@context"] = f"{get_host_domain()}/{get_api_name()}/contexts/{path}.jsonld"
     return object_
 
 

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -280,7 +280,7 @@ def add_iri_template(path: str, API_NAME: str, collection_path: str) -> Dict[str
 
     template, template_mappings = add_pagination_iri_mappings(template=template,
                                                               template_mapping=template_mappings)
-    return HydraIriTemplate(template=template, iri_mapping=template_mappings).generate()
+    return HydraIriTemplate(base_url=get_host_domain(), template=template, iri_mapping=template_mappings).generate()
 
 
 def generate_iri_mappings(path: str, template: str, skip_nested: bool = False,

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -280,7 +280,7 @@ def add_iri_template(path: str, API_NAME: str, collection_path: str) -> Dict[str
 
     template, template_mappings = add_pagination_iri_mappings(template=template,
                                                               template_mapping=template_mappings)
-    return HydraIriTemplate(base_url=get_host_domain(), template=template, iri_mapping=template_mappings).generate()
+    return HydraIriTemplate(template=template, iri_mapping=template_mappings).generate()
 
 
 def generate_iri_mappings(path: str, template: str, skip_nested: bool = False,

--- a/hydrus/tests/functional/test_app.py
+++ b/hydrus/tests/functional/test_app.py
@@ -19,6 +19,7 @@ from hydrus.utils import get_doc
 class TestApp():
     def test_Index(self, test_app_client, constants):
         """Test for the Index."""
+        HYDRUS_SERVER_URL = constants['HYDRUS_SERVER_URL']
         API_NAME = constants['API_NAME']
         response_get = test_app_client.get(f'/{API_NAME}')
         endpoints = json.loads(response_get.data.decode('utf-8'))
@@ -26,7 +27,7 @@ class TestApp():
         response_put = test_app_client.put(f'/{API_NAME}', data=dict(foo='bar'))
         response_delete = test_app_client.delete(f'/{API_NAME}')
         assert '@context' in endpoints
-        assert endpoints['@id'] == f'/{API_NAME}'
+        assert endpoints['@id'] == f'{HYDRUS_SERVER_URL}{API_NAME}'
         assert endpoints['@type'] == 'EntryPoint'
         assert response_get.status_code == 200
         assert response_post.status_code == 405


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #507 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.6.0 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
All paths starting with ```/...``` are changed with ```http://localhost:8000/...``` so that the link can be followed by clicking/reading/dereferencing the string. I have created a get_host_domain function to get the localhost and port. Please let me know if this isn't the right approach.



### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
-  Added get_host_domain function in _conf.py_

<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
- Changed f-strings to get new links.
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

New Output at ```http://localhost:8080/serverapi/DatastreamCollection```:
```
{
   "@context": "http://localhost:8080/serverapi/contexts/DatastreamCollection.jsonld",
   "@id": "http://localhost:8080/serverapi/DatastreamCollection/",
   "@type": "DatastreamCollection",
   "hydra:totalItems": 0,
   "hydra:view": {
   "@id": "http://localhost:8080/serverapi/DatastreamCollection?page=1",
   "@type": "hydra:PartialCollectionView",
   "hydra:first": "http://localhost:8080/serverapi/DatastreamCollection?page=1",
   "hydra:last": "http://localhost:8080/serverapi/DatastreamCollection?page=1"
   },
```
