### PR TITLE
chore: docker file deprication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM tiangolo/uwsgi-nginx-flask:python3.7
 # maybe we want to move to:
 # FROM tiangolo/meinheld-gunicorn-flask:python3.6
 
-MAINTAINER Akshay Dahiya <xadahiya@gmail.com>
+LABEL maintainer="Akshay Dahiya <xadahiya@gmail.com>"
 
 COPY ./requirements.txt requirements.txt
 # install certificates which were not installed in the base image
 RUN apt-get update && apt-get install -y ca-certificates
-RUN pip install -U pip && pip install --upgrade pip setuptools \ 
+RUN pip install -U pip && pip install --upgrade pip setuptools \
       && pip install -r requirements.txt && rm -rf *
 
 COPY  . /app


### PR DESCRIPTION
maintainer depreacted for LABEL

<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #535 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.6.0 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
[Reference](https://apimirror.com/docker~19/engine/deprecated/index) 
MAINTAINER was deprecated in v1.13.0 instead of it use of LABEL.

### Change logs
DockerFile Maintainer to LABEL

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
MAINTAINER Key from docker File