### PR TITLE
Added full domain for CRUD 

### DIFF
--- a/hydrus/data/crud.py
+++ b/hydrus/data/crud.py
@@ -84,7 +84,7 @@ def get(id_: str, type_: str, api_name: str, session: scoped_session,
     }
 
     object_template = get_object(query_info, session, collection)
-    object_template["@id"] = f"/{api_name}/{path}/{id_}"
+    object_template["@id"] = f"{get_host_domain()}/{api_name}/{path}/{id_}"
 
     return object_template
 
@@ -280,9 +280,9 @@ def get_single(type_: str, api_name: str, session: scoped_session,
     instance = get_single_response(session, type_)
     object_ = get(instance.id, type_, session=session, api_name=api_name, path=path)
     if path is not None:
-        object_["@id"] = f"/{api_name}/{path}"
+        object_["@id"] = f"{get_host_domain()}/{api_name}/{path}"
     else:
-        object_["@id"] = f"/{api_name}/{type_}"
+        object_["@id"] = f"{get_host_domain()}/{api_name}/{type_}"
     return object_
 
 

--- a/hydrus/helpers.py
+++ b/hydrus/helpers.py
@@ -232,7 +232,7 @@ def finalize_response(path: str, obj: Dict[str, Any]) -> Dict[str, Any]:
             member_path = get_path_from_type(member_type)
             member = {
                 "@type": "hydra:Link",
-                "@id": f"/{get_api_name()}/{member_path}/{member_id}",
+                "@id": f"{get_host_domain()}/{get_api_name()}/{member_path}/{member_id}",
             }
             members.append(member)
         obj['members'] = members


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #507 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.6.0 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
I missed these changes in previous PR, let me know if anything else is missing.
The domain name is missing in the `@id` field when making a GET request to `http://localhost:8080/serverapi/<resource_name>/<id>`. _Originally posted in https://github.com/HTTP-APIs/hydrus/issues/507#issuecomment-766796234_

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
New Response for GET :  `/<class_endpoint>/<id>`
```
{
    "@context": "http://localhost:8080/serverapi/contexts/Movie.jsonld",
    "@id": "http://localhost:8080/serverapi/Movie/01169a02-66b3-41c5-a3c9-e35d7d309e21",
    "@type": "Movie",
    "movie_director": "Todd Phillips",
    "movie_name": "Hangover"
}
```

For GET : `/<collection_endpoint>/<id>`
```
{
    "@context": "http://localhost:8080/serverapi/contexts/MovieCollection.jsonld",
    "@id": "http://localhost:8080/serverapi/MovieCollection/69f1c26b-bb56-4fae-9057-59fd0944e581",
    "@type": "MovieCollection",
    "members": [
        {
            "@id": "http://localhost:8080/serverapi/Movie/01169a02-66b3-41c5-a3c9-e35d7d309e21",
            "@type": "hydra:Link"
        }
    ]
}

```
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
