### PR TITLE
Logging using after_request method & hydrus_logger added

### DIFF
--- a/hydrus/LogConfig
+++ b/hydrus/LogConfig
@@ -1,0 +1,21 @@
+[loggers]
+keys=root
+
+[handlers]
+keys = FileHandler
+
+[formatters]
+keys=simpleFormatter
+
+[logger_root]
+handlers=FileHandler
+level = DEBUG
+
+[handler_FileHandler]
+class=FileHandler
+level=DEBUG
+args=('hydrus.log',)
+
+[formatter_simpleFormatter]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+datefmt=

--- a/hydrus/LogConfig
+++ b/hydrus/LogConfig
@@ -19,7 +19,6 @@ class = StreamHandler
 
 formatter=ConsoleFormatter
 args=(sys.stdout,)
-level = INFO
 
 [formatter_ConsoleFormatter]
 format=

--- a/hydrus/LogConfig
+++ b/hydrus/LogConfig
@@ -2,19 +2,27 @@
 keys=root
 
 [handlers]
-keys = FileHandler
+keys = FileHandler,StreamHandler
 
 [formatters]
-keys=simpleFormatter
+keys=simpleFormatter, ConsoleFormatter
 
 [logger_root]
-handlers=FileHandler
-level = DEBUG
+handlers=FileHandler, StreamHandler
 
 [handler_FileHandler]
 class=FileHandler
-level=DEBUG
 args=('hydrus.log',)
+
+[handler_StreamHandler]
+class = StreamHandler
+
+formatter=ConsoleFormatter
+args=(sys.stdout,)
+level = INFO
+
+[formatter_ConsoleFormatter]
+format=
 
 [formatter_simpleFormatter]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/hydrus/app_factory.py
+++ b/hydrus/app_factory.py
@@ -24,7 +24,8 @@ def app_factory(api_name: str = "api", vocab_route: str = "vocab") -> Flask:
     @app.after_request
     def logging_request_response(response):
         logger = HydrusLogger().get_logger()
-        logger.info("{} {}/<iri>".format(uuid.uuid4(), request.method))
+        logger.info(" {} {}:{} Object_created_at : {}, status_code : {} "
+                    .format(uuid.uuid4(), request.method, request.path, response.location, response.status))
         return response
 
     # Redirecting root_path to root_path/api_name

--- a/hydrus/app_factory.py
+++ b/hydrus/app_factory.py
@@ -1,7 +1,8 @@
-from flask import Flask, redirect
+from flask import Flask, redirect, request
+import uuid
 from flask_cors import CORS
 from flask_restful import Api
-
+from hydrus_logger import HydrusLogger
 from hydrus.resources import (Index, Vocab, Contexts, Entrypoint,
                               ItemCollection, Item, Items, ItemMember)
 
@@ -19,6 +20,12 @@ def app_factory(api_name: str = "api", vocab_route: str = "vocab") -> Flask:
     CORS(app)
     app.url_map.strict_slashes = False
     api = Api(app)
+
+    @app.after_request
+    def logging_request_response(response):
+        logger = HydrusLogger().get_logger()
+        logger.info("{} {}/<iri>".format(uuid.uuid4(), request.method))
+        return response
 
     # Redirecting root_path to root_path/api_name
     if api_name:

--- a/hydrus/app_factory.py
+++ b/hydrus/app_factory.py
@@ -5,7 +5,7 @@ from flask_restful import Api
 from hydrus_logger import HydrusLogger
 from hydrus.resources import (Index, Vocab, Contexts, Entrypoint,
                               ItemCollection, Item, Items, ItemMember)
-
+logger = HydrusLogger().get_logger()
 
 def app_factory(api_name: str = "api", vocab_route: str = "vocab") -> Flask:
     """
@@ -21,9 +21,9 @@ def app_factory(api_name: str = "api", vocab_route: str = "vocab") -> Flask:
     app.url_map.strict_slashes = False
     api = Api(app)
 
+
     @app.after_request
     def logging_request_response(response):
-        logger = HydrusLogger().get_logger()
         logger.info(" {} {}:{} Object_created_at : {}, status_code : {} "
                     .format(uuid.uuid4(), request.method, request.path, response.location, response.status))
         return response

--- a/hydrus/app_factory.py
+++ b/hydrus/app_factory.py
@@ -5,7 +5,9 @@ from flask_restful import Api
 from hydrus_logger import HydrusLogger
 from hydrus.resources import (Index, Vocab, Contexts, Entrypoint,
                               ItemCollection, Item, Items, ItemMember)
+
 logger = HydrusLogger().get_logger()
+
 
 def app_factory(api_name: str = "api", vocab_route: str = "vocab") -> Flask:
     """
@@ -21,11 +23,14 @@ def app_factory(api_name: str = "api", vocab_route: str = "vocab") -> Flask:
     app.url_map.strict_slashes = False
     api = Api(app)
 
-
     @app.after_request
     def logging_request_response(response):
-        logger.info(" {} {}:{} Object_created_at : {}, status_code : {} "
-                    .format(uuid.uuid4(), request.method, request.path, response.location, response.status))
+        if response.location and response.status_code != 302:
+            logger.info(" {} {}:{} Object_created_at : {}, status_code : {} "
+                        .format(uuid.uuid4(), request.method, request.path, response.location, response.status))
+        else:
+            logger.info(" {} {}:{}  status_code : {} "
+                        .format(uuid.uuid4(), request.method, request.path, response.status))
         return response
 
     # Redirecting root_path to root_path/api_name

--- a/hydrus/hydrus_logger.py
+++ b/hydrus/hydrus_logger.py
@@ -1,0 +1,14 @@
+import logging
+import logging.config
+import structlog
+
+
+class HydrusLogger:
+    def __init__(self):
+        logging.config.fileConfig('LogConfig')
+        structlog.wrap_logger(logging.getLogger())
+        structlog.configure(logger_factory=structlog.stdlib.LoggerFactory())
+        self.logger = structlog.get_logger()
+
+    def get_logger(self):
+        return self.logger

--- a/hydrus/hydrus_logger.py
+++ b/hydrus/hydrus_logger.py
@@ -1,10 +1,11 @@
 import logging
 import logging.config
 import structlog
-
+import os
 
 class HydrusLogger:
     def __init__(self):
+        logging.basicConfig(level = os.environ.get('LOGLEVEL', 'DEBUG'))
         logging.config.fileConfig('LogConfig')
         structlog.wrap_logger(logging.getLogger())
         structlog.configure(logger_factory=structlog.stdlib.LoggerFactory())

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ six==1.13.0
 SQLAlchemy==1.3.12
 thespian==3.9.11
 Werkzeug==0.16.0
+structlog


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #572

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.6.0 and above.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
We don't have any logging mechanism for hydrus.
### New expected behaviour
<!-- Describe the new code and its expected behaviour -->
I have tried to add the things covered in [this discussion](https://github.com/HTTP-APIs/hydrus/issues/572), Opening this PR for more clear Suggestions.

1. I have added a `after_request` method where we are logging the `TimeStamp job_Id Method / iri` (resource_url is not fetched now) 
2.  Created `hydrus_logger.py` which provide us configured structlog logger object
3. `LogConfig` file for configuring the logger object.
4.  Logs Directory is not setup yet, `hydrus.log` will be generated in the same directory.

![Screenshot from 2021-05-15 05-27-47](https://user-images.githubusercontent.com/49719371/118341851-5db9f580-b53e-11eb-9762-2d809f305add.png)

