### PR TITLE
Added functional tests for PUT/DELETE multiple class objects

### DIFF
--- a/hydrus/data/helpers/items_helpers.py
+++ b/hydrus/data/helpers/items_helpers.py
@@ -121,7 +121,7 @@ def items_delete_response(path: str, int_list="") -> Response:
     """
     _, parsed_classes = get_collections_and_parsed_classes()
     if path in parsed_classes:
-        class_type = getType(path, "DELETE")
+        class_type = parsed_classes[path]["class"].title
 
     if checkClassOp(class_type, "DELETE"):
         # Check if class_type supports PUT operation

--- a/tests/functional/test_app.py
+++ b/tests/functional/test_app.py
@@ -313,17 +313,40 @@ class TestApp():
                     class_methods = [x.method for x in class_.supportedOperation]
                     data_ = {'data': list()}
                     objects = list()
-                    ids = ''
+                    ids_list = list()
                     for index in range(3):
                         objects.append(gen_dummy_object(class_.title, doc))
-                        ids = f'{uuid.uuid4()},'
+                        ids_list.append(f'{uuid.uuid4()}')
                     data_['data'] = objects
                     if 'PUT' in class_methods:
+                        ids = ','.join(ids_list)
                         put_response = test_app_client.put(f'{endpoints[endpoint]}?instances={ids}',
                                                            data=json.dumps(data_))
                         assert put_response.status_code == 201
                         assert isinstance(put_response.json['iri'], list)
 
+    def test_multiple_object_PUT_without_ids(self, test_app_client, constants, doc):
+        API_NAME = constants['API_NAME']
+        index = test_app_client.get(f'/{API_NAME}')
+        assert index.status_code == 200
+        endpoints = json.loads(index.data.decode('utf-8'))
+        for endpoint in endpoints:
+            if endpoint not in ['@context', '@id', '@type', 'collections']:
+                class_name = '/'.join(endpoints[endpoint].split(f'/{API_NAME}/')[1:])
+                if class_name not in doc.collections:
+                    class_ = doc.parsed_classes[class_name]['class']
+                    class_methods = [x.method for x in class_.supportedOperation]
+                    data_ = {'data': list()}
+                    objects = list()
+                    for index in range(3):
+                        objects.append(gen_dummy_object(class_.title, doc))
+                    data_['data'] = objects
+                    if 'PUT' in class_methods:
+                        put_response = test_app_client.put(f'{endpoints[endpoint]}',
+                                                           data=json.dumps(data_))
+                        assert put_response.status_code == 201
+                        assert isinstance(put_response.json['iri'], list)
+    
     def test_endpointClass_PUT(self, test_app_client, constants, doc):
         """Check non collection Class PUT."""
         API_NAME = constants['API_NAME']

--- a/tests/functional/test_app.py
+++ b/tests/functional/test_app.py
@@ -346,6 +346,35 @@ class TestApp():
                                                            data=json.dumps(data_))
                         assert put_response.status_code == 201
                         assert isinstance(put_response.json['iri'], list)
+
+    def test_multiple_object_DELETE(self, test_app_client, constants, doc):
+        API_NAME = constants['API_NAME']
+        index = test_app_client.get(f'/{API_NAME}')
+        assert index.status_code == 200
+        endpoints = json.loads(index.data.decode('utf-8'))
+        for endpoint in endpoints:
+            if endpoint not in ['@context', '@id', '@type', 'collections']:
+                class_name = '/'.join(endpoints[endpoint].split(f'/{API_NAME}/')[1:])
+                if class_name not in doc.collections:
+                    class_ = doc.parsed_classes[class_name]['class']
+                    class_methods = [x.method for x in class_.supportedOperation]
+                    data_ = {'data': list()}
+                    objects = list()
+                    ids_list = list()
+                    for index in range(3):
+                        objects.append(gen_dummy_object(class_.title, doc))
+                        ids_list.append(f'{uuid.uuid4()}')
+                    data_['data'] = objects
+                    if 'PUT' in class_methods:
+                        ids = ','.join(ids_list)
+                        full_endpoint = f'{endpoints[endpoint]}?instances={ids}'
+                        put_response = test_app_client.put(full_endpoint,
+                                                           data=json.dumps(data_))
+                        assert put_response.status_code == 201
+                        assert isinstance(put_response.json['iri'], list)
+                        if 'DELETE' in class_methods:
+                            delete_response = test_app_client.delete(full_endpoint)
+                            assert delete_response.status_code == 200
     
     def test_endpointClass_PUT(self, test_app_client, constants, doc):
         """Check non collection Class PUT."""


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #586 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.6.0 and above.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
We didn't had any tests for PUT/DELETE request for multiple Class objects in test_app.py.
We do have some tests in test_crud.py, but we’re directly using functions from crud.py to
test the behaviour and not making requests to the endpoints to check status codes.
Also, there was some logical bug in an existing test, so I fixed it.

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->

### Change logs
- Fixed test : test_object_PUT_at_ids
- Added test : test_multiple_object_PUT_without_ids
- Added test : test_multiple_object_DELETE

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
