### PR TITLE
Fix get_host_domain function for deployment

### DIFF
--- a/hydrus/conf.py
+++ b/hydrus/conf.py
@@ -12,6 +12,7 @@ import os
 import json
 import yaml
 import logging
+from flask import g
 from os.path import abspath, dirname
 from pathlib import Path
 from importlib.machinery import SourceFileLoader
@@ -100,8 +101,11 @@ def get_host_domain():
     """
     Returns host domain.
     """
-    HOST_DOMAIN = f"http://localhost:{PORT}"
-    return HOST_DOMAIN
+    try:
+        hydrus_server_url = getattr(g, "hydrus_server_url")[:-1]
+    except (AttributeError, RuntimeError):
+        hydrus_server_url = f"http://localhost:{PORT}"
+    return hydrus_server_url
 
 
 (path, FOUND_DOC) = get_apidoc_path()

--- a/hydrus/data/crud_helpers.py
+++ b/hydrus/data/crud_helpers.py
@@ -162,11 +162,11 @@ def attach_hydra_view(
         if offset > page_size:
             collection_template["hydra:view"][
                 "hydra:previous"
-            ] = f"{iri}{paginate_param}={offset - page_size}"
+            ] = f"{get_host_domain()}{iri}{paginate_param}={offset - page_size}"
         if offset < result_length - page_size:
             collection_template["hydra:view"][
                 "hydra:next"
-            ] = f"{iri}{paginate_param}={offset + page_size}"
+            ] = f"{get_host_domain()}{iri}{paginate_param}={offset + page_size}"
     else:
         collection_template["hydra:view"] = {
             "@id": f"{get_host_domain()}{iri}{paginate_param}={page}",
@@ -177,8 +177,8 @@ def attach_hydra_view(
         if page != 1:
             collection_template["hydra:view"][
                 "hydra:previous"
-            ] = f"{iri}{paginate_param}={page-1}"
+            ] = f"{get_host_domain()}{iri}{paginate_param}={page-1}"
         if page != last:
             collection_template["hydra:view"][
                 "hydra:next"
-            ] = f"{iri}{paginate_param}={page + 1}"
+            ] = f"{get_host_domain()}{iri}{paginate_param}={page + 1}"


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #602 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.6.0 and above.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
I was trying to deploy the docker-container after changing the hydrus_server_url and found a possible bug, which wasn't allowing us to change it to something else other than `"localhost:{PORT}"`.  In _hydrus/conf.py_ it was hardcoded to `"localhost"`.
### New expected behaviour
<!-- Describe the new code and its expected behaviour -->
* I used flask's `g` variable to get the `hydrus_server_url`. Also had to check for RuntimeError (running out of app context ) in case of test_crud.
* Changed get_host_domain() function. It will try to use URL provided by URL in main.py, otherwise in case of AttributeError or RuntimeError it'll stick to localhost.

### Change logs
* changed get_host_domain in conf.py
* minor changes in attach_hydra_view
<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
