### PR TITLE
Incorrect syntax for console_scripts (provided by Click python package) used in our project

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,9 @@ setup(
     install_requires=dependencies,
     packages=find_packages(exclude=["contrib", "docs", "tests*", "hydrus.egg-info"]),
     package_dir={"hydrus": "hydrus"},
-    entry_points="""
-            [console_scripts]
-            hydrus=cli:startserver
-        """,
+    entry_points={
+        'console_scripts': [
+            'hydrus = cli:startserver',
+        ],
+    },
 )


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #614 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.6.0 and above.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
`hydrus serve` gives error `hydrus: no such file or directory`

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->
Now `hydrus serve` runs the server and a demo is up and running on http://localhost:8080/serverapi/

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->
Previously in setup.py: 
![Screenshot from 2022-02-25 11-22-44](https://user-images.githubusercontent.com/50960175/155662113-86ee9f34-4c97-4751-869b-cb311fe4f1c9.png)

Now in setup.py: 
![Screenshot from 2022-02-25 11-24-11](https://user-images.githubusercontent.com/50960175/155662225-01d28c02-58e6-41f5-b833-d2b9db0c09fa.png)



<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
